### PR TITLE
docs: cross-link to central Platform mechanics reference

### DIFF
--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -234,6 +234,9 @@ Adjust `max_stream_response_bytes` in `LangGraphApp` if your graph produces larg
 This is an Azure Functions Python worker limitation for HTTP streaming/chunked transfer.
 The package currently collects stream events and returns a single response body.
 
+> For how the Azure Functions Python worker loads and binds handlers, see the toolkit's
+> [Platform mechanics](https://yeongseon.dev/azure-functions-python/platform/) reference.
+
 ### Operational recommendation
 
 For long-running production runs, prefer:

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -235,7 +235,7 @@ This is an Azure Functions Python worker limitation for HTTP streaming/chunked t
 The package currently collects stream events and returns a single response body.
 
 > For how the Azure Functions Python worker loads and binds handlers, see the toolkit's
-> [Platform mechanics](https://yeongseon.dev/azure-functions-python/platform/) reference.
+> [how the worker binds handlers](https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/) reference — how invocation_id / handler binding works.
 
 ### Operational recommendation
 


### PR DESCRIPTION
## Summary
- Add a cross-link from `docs/production-guide.md` (worker streaming-limit note) to the toolkit's central [Platform mechanics](https://yeongseon.dev/azure-functions-python/platform/) reference.
- Link-only consumer: no platform narrative is duplicated in this repo.

Closes #379