### PR TITLE
test(e2e): prove single-writer exclusivity across two Azure Function Apps

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -47,12 +47,14 @@ jobs:
           RUN="${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
           RG="rg-af-e2e-${REPO_SHORT}-${RUN}"
           APP="af-e2e-${REPO_SHORT}-${RUN}"
+          APP_B="af-e2e-${REPO_SHORT}-${RUN}-b"
           # Storage name: lowercase alphanumeric, max 24 chars
           ST="stafe2e${RUN}"
           ST="${ST:0:24}"
-          echo "rg=${RG}"   >> "$GITHUB_OUTPUT"
-          echo "app=${APP}" >> "$GITHUB_OUTPUT"
-          echo "st=${ST}"   >> "$GITHUB_OUTPUT"
+          echo "rg=${RG}"     >> "$GITHUB_OUTPUT"
+          echo "app=${APP}"   >> "$GITHUB_OUTPUT"
+          echo "app_b=${APP_B}" >> "$GITHUB_OUTPUT"
+          echo "st=${ST}"     >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
         uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
@@ -76,6 +78,7 @@ jobs:
             --parameters \
                 location="$AZURE_LOCATION" \
                 functionAppName="${{ steps.names.outputs.app }}" \
+                functionAppNameB="${{ steps.names.outputs.app_b }}" \
                 storageName="${{ steps.names.outputs.st }}" \
                 enableAppInsights=false
 
@@ -113,15 +116,20 @@ jobs:
           pip install -e ".[dev]"
           pip install requests
 
-      - name: Publish function app
+      - name: Publish function apps (App A and App B)
         working-directory: examples/e2e_app
-        timeout-minutes: 30
+        timeout-minutes: 40
         run: |
+          # Deploy the SAME candidate payload to both hosts. They share one
+          # storage account, one lock container, and one checkpoint container,
+          # so they genuinely contend for a single lease per thread_id.
           func azure functionapp publish "${{ steps.names.outputs.app }}" --python --build remote
+          func azure functionapp publish "${{ steps.names.outputs.app_b }}" --python --build remote
 
       - name: Run e2e tests
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+          E2E_BASE_URL_B: https://${{ steps.names.outputs.app_b }}.azurewebsites.net
         run: |
           # Clear the repo's default addopts (which force '-m "not e2e"' and
           # coverage) so the e2e-marked suite is actually collected.

--- a/examples/e2e_app/README.md
+++ b/examples/e2e_app/README.md
@@ -11,8 +11,24 @@ It differs from the user-facing `examples/simple_agent` in two ways:
    commit, drops it in `wheels/`, and appends the local wheel path so the
    deployed host runs the exact source being certified (not the PyPI release).
 2. **Native routes only.** `LangGraphApp()` is created without
-   `platform_compat`, so no Blob/Table storage is required — the graph name is
-   `e2e_agent`.
+   `platform_compat`. The baseline greeting graph `e2e_agent` has no
+   checkpointer and needs only `AzureWebJobsStorage`.
+
+It also registers a second graph, **`e2e_lock_agent`** (issue #386), used to
+prove single-writer exclusivity across two Function Apps. Unlike `e2e_agent` it
+*does* use Azure Blob storage: it is wired with an `AzureBlobLeaseThreadLock`
+(distributed lease container) and an `AzureBlobCheckpointSaver` (single-writer
+checkpoint container). Both containers live in the same storage account as
+`AzureWebJobsStorage` and are pre-created by `infra/main.bicep`. The workflow
+deploys this same payload to **two** Function Apps (App A and App B) that share
+those containers; `tests/e2e/test_langgraph_lock_e2e.py` then drives a
+concurrent same-`thread_id` invoke against both and asserts exactly one writer
+wins (the loser gets HTTP 409). That two-app test skips unless both
+`E2E_BASE_URL` and `E2E_BASE_URL_B` are set, so the single-app certification
+path is unaffected.
+
+Relevant app settings (identical on both hosts): `E2E_LOCK_CONTAINER`,
+`E2E_CHECKPOINT_CONTAINER`, and optional `E2E_LOCK_HOLD_SECONDS` (default 20).
 
 To reproduce locally you must first place a built wheel in `wheels/` and add it
 to `requirements.txt`, then `func start`.

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -44,6 +44,7 @@ langgraph_app.register(
 # two hosts genuinely contend for one lease. Guarded so a wiring failure never
 # breaks the baseline e2e_agent certification.
 try:
+    from azure.core.exceptions import ResourceExistsError
     from azure.storage.blob import ContainerClient
 
     from lock_graph import compiled_lock_graph
@@ -57,7 +58,10 @@ try:
     )
     try:
         _lock_container.create_container()  # idempotent — Bicep pre-creates it
-    except Exception:  # pragma: no cover - depends on live Azure state
+    except ResourceExistsError:  # pragma: no cover - depends on live Azure state
+        # Container already exists (Bicep pre-created it, or a benign concurrent
+        # create). Any other error (auth/RBAC/network) propagates to the outer
+        # handler so the wiring failure is logged instead of silently masked.
         pass
 
     langgraph_app.thread_lock = AzureBlobLeaseThreadLock(container_client=_lock_container)

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -1,13 +1,24 @@
 """E2E certification Function App for azure-functions-langgraph.
 
-Deployed to a real Azure Functions Consumption host by the e2e-azure workflow.
-Exposes only the NATIVE LangGraph routes (no platform_compat), which require
-only AzureWebJobsStorage:
+Deployed to real Azure Functions Consumption hosts by the e2e-azure workflow.
+Exposes the NATIVE LangGraph routes (no platform_compat):
 
     GET  /api/health
     POST /api/graphs/e2e_agent/invoke
     POST /api/graphs/e2e_agent/stream
+
+    # Two-app single-writer exclusivity certification (#386):
+    POST /api/graphs/e2e_lock_agent/invoke
+    GET  /api/graphs/e2e_lock_agent/threads/{thread_id}/state
+
+The same app payload is deployed to TWO Function Apps (App A and App B) that
+share one storage account, one lock Blob container, and one checkpoint Blob
+container. Concurrent invokes of ``e2e_lock_agent`` with the same ``thread_id``
+must resolve to exactly one writer (the loser receives HTTP 409), proving the
+distributed :class:`AzureBlobLeaseThreadLock` + owner-safe release across hosts.
 """
+
+import os
 
 import azure.functions as func
 
@@ -24,5 +35,42 @@ langgraph_app.register(
     name="e2e_agent",
     description="Two-node greeting agent used for real-Azure e2e certification",
 )
+
+# ── Distributed-lock exclusivity graph (#386) ──────────────────────────────
+# Registered alongside e2e_agent so the existing health/invoke/stream cert path
+# is unchanged. Wired with a distributed AzureBlobLeaseThreadLock (shared lock
+# container) and a single-writer AzureBlobCheckpointSaver (shared checkpoint
+# container). Both are keyed off the SAME app settings on App A and App B so the
+# two hosts genuinely contend for one lease. Guarded so a wiring failure never
+# breaks the baseline e2e_agent certification.
+try:
+    from azure.storage.blob import ContainerClient
+
+    from lock_graph import compiled_lock_graph
+
+    from azure_functions_langgraph.locks import AzureBlobLeaseThreadLock
+
+    _connection_string = os.environ["AzureWebJobsStorage"]
+    _lock_container_name = os.environ.get("E2E_LOCK_CONTAINER", "langgraph-locks")
+    _lock_container = ContainerClient.from_connection_string(
+        _connection_string, _lock_container_name
+    )
+    try:
+        _lock_container.create_container()  # idempotent — Bicep pre-creates it
+    except Exception:  # pragma: no cover - depends on live Azure state
+        pass
+
+    langgraph_app.thread_lock = AzureBlobLeaseThreadLock(container_client=_lock_container)
+    langgraph_app.register(
+        graph=compiled_lock_graph,
+        name="e2e_lock_agent",
+        description="Distributed-lock exclusivity graph for two-app e2e certification",
+    )
+except Exception:  # pragma: no cover - keep baseline e2e_agent cert resilient
+    import logging
+
+    logging.getLogger(__name__).exception(
+        "e2e_lock_agent wiring failed; continuing with e2e_agent only"
+    )
 
 app = langgraph_app.function_app

--- a/examples/e2e_app/lock_graph.py
+++ b/examples/e2e_app/lock_graph.py
@@ -29,6 +29,7 @@ import time
 import uuid
 from typing import Any, TypedDict
 
+from azure.core.exceptions import ResourceExistsError
 from azure.storage.blob import ContainerClient
 from langgraph.graph import END, START, StateGraph
 
@@ -86,8 +87,10 @@ def _build_checkpointer() -> AzureBlobCheckpointSaver:
     # and local (Azurite) reproduction where it may not yet exist.
     try:
         container_client.create_container()
-    except Exception:  # pragma: no cover - depends on live Azure state
-        # Already exists (or a benign concurrent create). Safe to ignore.
+    except ResourceExistsError:  # pragma: no cover - depends on live Azure state
+        # Already exists (or a benign concurrent create). Safe to ignore. Any
+        # other error (bad connection string, missing RBAC, outage) propagates
+        # so wiring fails fast and surfaces the real root cause.
         pass
     return AzureBlobCheckpointSaver(container_client=container_client)
 

--- a/examples/e2e_app/lock_graph.py
+++ b/examples/e2e_app/lock_graph.py
@@ -1,0 +1,102 @@
+"""Two-app single-writer exclusivity graph for real-Azure e2e certification (#386).
+
+This graph proves the core value proposition of :class:`AzureBlobLeaseThreadLock`
++ a single-writer checkpointer: two Function App instances invoking the SAME
+``thread_id`` concurrently must NOT both mutate the checkpoint. Exactly one
+execution enters the mutation section; the other is rejected with HTTP 409.
+
+Shape (deliberately two nodes, not one)::
+
+    START -> enter -> hold -> END
+
+``enter`` writes the ``entered`` marker and returns, so LangGraph persists a
+checkpoint *between* super-steps — this is what lets the driving test observe
+``entered`` (via ``GET .../threads/{thread_id}/state``) while the winning
+execution is still holding the lease inside ``hold``. A single node that wrote
+``entered``, slept, then wrote ``completed`` would only checkpoint *after* the
+sleep, defeating the deterministic gate.
+
+The compiled graph is wired with an :class:`AzureBlobCheckpointSaver` so state
+survives across the two Function Apps (which share one storage account and one
+checkpoint container). The distributed lock itself is wired at the app level in
+``function_app.py`` via :class:`AzureBlobLeaseThreadLock`.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Any, TypedDict
+
+from azure.storage.blob import ContainerClient
+from langgraph.graph import END, START, StateGraph
+
+from azure_functions_langgraph.checkpointers.azure_blob import AzureBlobCheckpointSaver
+
+# How long the winning execution holds the lease inside the mutation section.
+# Must comfortably exceed the driving test's observe-then-fire-loser latency so
+# the loser's request lands while the lease is still held. Overridable via app
+# setting for tuning without a code change.
+HOLD_SECONDS = float(os.environ.get("E2E_LOCK_HOLD_SECONDS", "20"))
+
+# Container names are supplied as app settings so App A and App B receive the
+# SAME values and therefore share one lock container and one checkpoint
+# container. Pre-created by infra/main.bicep to avoid cold-start create races.
+CHECKPOINT_CONTAINER = os.environ.get("E2E_CHECKPOINT_CONTAINER", "langgraph-checkpoints")
+
+
+class LockState(TypedDict):
+    """State channels for the lock-exclusivity graph.
+
+    ``run_id`` is supplied by the caller so the driving test can prove which
+    execution won: the final checkpoint must reflect exactly one ``run_id``.
+    """
+
+    messages: list[dict[str, str]]
+    run_id: str
+    entered: str
+    completed: str
+
+
+def enter(state: LockState) -> dict[str, Any]:
+    """Record that this execution entered the mutation section.
+
+    Returns immediately so LangGraph checkpoints ``entered`` before ``hold``
+    runs — making the marker observable via the state endpoint while the lease
+    is still held.
+    """
+    run_id = state.get("run_id") or uuid.uuid4().hex
+    return {"run_id": run_id, "entered": run_id}
+
+
+def hold(state: LockState) -> dict[str, Any]:
+    """Hold the lease long enough to guarantee overlap, then mark completion."""
+    time.sleep(HOLD_SECONDS)
+    return {"completed": state["run_id"]}
+
+
+def _build_checkpointer() -> AzureBlobCheckpointSaver:
+    """Build the single-writer Blob checkpointer from ``AzureWebJobsStorage``."""
+    connection_string = os.environ["AzureWebJobsStorage"]
+    container_client = ContainerClient.from_connection_string(
+        connection_string, CHECKPOINT_CONTAINER
+    )
+    # Idempotent — the container is pre-created by Bicep, but tolerate reruns
+    # and local (Azurite) reproduction where it may not yet exist.
+    try:
+        container_client.create_container()
+    except Exception:  # pragma: no cover - depends on live Azure state
+        # Already exists (or a benign concurrent create). Safe to ignore.
+        pass
+    return AzureBlobCheckpointSaver(container_client=container_client)
+
+
+builder = StateGraph(LockState)
+builder.add_node("enter", enter)
+builder.add_node("hold", hold)
+builder.add_edge(START, "enter")
+builder.add_edge("enter", "hold")
+builder.add_edge("hold", END)
+
+compiled_lock_graph = builder.compile(checkpointer=_build_checkpointer())

--- a/examples/e2e_app/requirements.txt
+++ b/examples/e2e_app/requirements.txt
@@ -10,3 +10,6 @@
 azure-functions
 langgraph>=1.0,<2.0
 langchain-core>=1.0,<2.0
+# Required by the two-app single-writer exclusivity graph (#386): the
+# AzureBlobLeaseThreadLock + AzureBlobCheckpointSaver used by e2e_lock_agent.
+azure-storage-blob>=12.0,<13

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,11 +15,20 @@
 @description('Azure region for all resources.')
 param location string = resourceGroup().location
 
-@description('Name of the Function App (must be globally unique).')
+@description('Name of the Function App (must be globally unique). This is App A.')
 param functionAppName string
 
-@description('Name of the Storage Account (3-24 lowercase alphanumeric).')
+@description('Name of the second Function App for the two-app single-writer e2e (#386). This is App B. Empty string skips App B.')
+param functionAppNameB string = ''
+
+@description('Name of the Storage Account (3-24 lowercase alphanumeric). Shared by App A and App B.')
 param storageName string
+
+@description('Blob container for AzureBlobLeaseThreadLock leases (shared by both apps).')
+param lockContainerName string = 'langgraph-locks'
+
+@description('Blob container for AzureBlobCheckpointSaver checkpoints (shared by both apps).')
+param checkpointContainerName string = 'langgraph-checkpoints'
 
 @description('Enable Application Insights (set true for logging e2e).')
 param enableAppInsights bool = false
@@ -40,6 +49,47 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
 }
 
 var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+
+// ── Blob containers (pre-created to avoid cold-start create races) ──────────
+// Both Function Apps share these two containers: one for AzureBlobLeaseThreadLock
+// leases, one for AzureBlobCheckpointSaver checkpoints. Pre-creating them here
+// makes deployment deterministic instead of relying on runtime create_container().
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource lockContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: lockContainerName
+}
+
+resource checkpointContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: checkpointContainerName
+}
+
+// Shared app settings for App A and App B. Identical container names on both
+// hosts are what make the two apps genuinely contend for one lease / one
+// checkpoint namespace.
+var baseAppSettings = concat(
+  [
+    { name: 'AzureWebJobsStorage', value: storageConnectionString }
+    { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+    { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
+    { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT', value: 'true' }
+    { name: 'E2E_LOCK_CONTAINER', value: lockContainerName }
+    { name: 'E2E_CHECKPOINT_CONTAINER', value: checkpointContainerName }
+  ],
+  enableAppInsights
+    ? [
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsights.properties.ConnectionString
+        }
+      ]
+    : []
+)
 
 // ── App Insights (optional) ────────────────────────────────────────────────
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = if (enableAppInsights) {
@@ -75,22 +125,38 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
     serverFarmId: hostingPlan.id
     siteConfig: {
       linuxFxVersion: 'Python|3.10'
-      appSettings: concat(
-        [
-          { name: 'AzureWebJobsStorage', value: storageConnectionString }
-          { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
-          { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
-          { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT', value: 'true' }
-        ],
-        enableAppInsights
-          ? [
-              {
-                name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-                value: appInsights.properties.ConnectionString
-              }
-            ]
-          : []
-      )
+      appSettings: baseAppSettings
+    }
+    httpsOnly: true
+  }
+}
+
+// ── App B (two-app single-writer exclusivity, #386) ────────────────────────
+// A second, fully independent Function App on its own Consumption plan, sharing
+// the SAME storage account, lock container, and checkpoint container as App A.
+// Created only when functionAppNameB is provided.
+resource hostingPlanB 'Microsoft.Web/serverfarms@2023-01-01' = if (functionAppNameB != '') {
+  name: '${functionAppNameB}-plan'
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+  kind: 'linux'
+  properties: {
+    reserved: true
+  }
+}
+
+resource functionAppB 'Microsoft.Web/sites@2023-01-01' = if (functionAppNameB != '') {
+  name: functionAppNameB
+  location: location
+  kind: 'functionapp,linux'
+  properties: {
+    serverFarmId: hostingPlanB.id
+    siteConfig: {
+      linuxFxVersion: 'Python|3.10'
+      appSettings: baseAppSettings
     }
     httpsOnly: true
   }
@@ -99,6 +165,10 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
 // ── Outputs ────────────────────────────────────────────────────────────────
 output functionAppName string = functionApp.name
 output defaultHostName string = functionApp.properties.defaultHostName
+output functionAppNameB string = functionAppNameB
+output defaultHostNameB string = functionAppNameB != ''
+  ? functionAppB.properties.defaultHostName
+  : ''
 output appInsightsConnectionString string = enableAppInsights
   ? appInsights.properties.ConnectionString
   : ''

--- a/tests/e2e/test_langgraph_lock_e2e.py
+++ b/tests/e2e/test_langgraph_lock_e2e.py
@@ -1,0 +1,135 @@
+"""Two-app single-writer exclusivity e2e (#386).
+
+Proves the core distributed-lock guarantee of ``AzureBlobLeaseThreadLock`` +
+a single-writer checkpointer across TWO independent Azure Function Apps: when
+both hosts invoke the same ``thread_id`` concurrently, exactly one execution
+mutates the checkpoint and the other is rejected with HTTP 409.
+
+The race is made **deterministic** (not a flaky "fire both simultaneously"
+gamble) by gating on observed state:
+
+1. Start App A's invoke asynchronously (it enters the mutation section, writes
+   an ``entered`` marker, then holds the lease for ``E2E_LOCK_HOLD_SECONDS``).
+2. Poll the shared checkpoint via App A's state endpoint until ``entered``
+   equals App A's run id — proving A is inside the locked section and still
+   holding the lease.
+3. Only then fire App B with the same ``thread_id``; assert B gets 409.
+4. Let App A finish (200) and assert the final checkpoint reflects exactly one
+   run id (App A's) — App B never wrote anything.
+
+Requires BOTH ``E2E_BASE_URL`` (App A) and ``E2E_BASE_URL_B`` (App B). Skips
+otherwise, so ordinary unit runs (``-m "not e2e"``) and single-app local e2e
+runs never hit this test.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+import os
+import time
+import uuid
+
+import pytest
+import requests
+
+BASE_URL_A = os.environ.get("E2E_BASE_URL", "").rstrip("/")
+BASE_URL_B = os.environ.get("E2E_BASE_URL_B", "").rstrip("/")
+GRAPH = "e2e_lock_agent"
+SKIP_REASON = "E2E_BASE_URL and E2E_BASE_URL_B must both be set — skipping two-app exclusivity e2e"
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(not (BASE_URL_A and BASE_URL_B), reason=SKIP_REASON),
+]
+
+
+def _invoke(base_url: str, thread_id: str, run_id: str) -> requests.Response:
+    payload = {
+        "input": {"messages": [], "run_id": run_id},
+        "config": {"configurable": {"thread_id": thread_id}},
+    }
+    return requests.post(
+        f"{base_url}/api/graphs/{GRAPH}/invoke",
+        json=payload,
+        timeout=120,
+    )
+
+
+def _get_state_values(base_url: str, thread_id: str) -> dict[str, object]:
+    r = requests.get(
+        f"{base_url}/api/graphs/{GRAPH}/threads/{thread_id}/state",
+        timeout=30,
+    )
+    if r.status_code == 404:
+        return {}
+    r.raise_for_status()
+    body = r.json()
+    values = body.get("values")
+    return values if isinstance(values, dict) else {}
+
+
+def _wait_for_entered(base_url: str, thread_id: str, run_id: str, timeout: float) -> None:
+    """Poll the shared checkpoint until ``entered`` == ``run_id`` (bounded)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        values = _get_state_values(base_url, thread_id)
+        if values.get("entered") == run_id:
+            return
+        time.sleep(1)
+    raise AssertionError(
+        f"App A never recorded entered={run_id!r} within {timeout}s "
+        f"(last state values: {_get_state_values(base_url, thread_id)})"
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def warmup_both_apps() -> None:
+    """Retry /api/health on both hosts until Consumption cold-start finishes."""
+    for base_url in (BASE_URL_A, BASE_URL_B):
+        deadline = time.time() + 180
+        last_exc: Exception | None = None
+        while time.time() < deadline:
+            try:
+                r = requests.get(f"{base_url}/api/health", timeout=15)
+                if r.status_code == 200:
+                    break
+            except requests.RequestException as exc:  # pragma: no cover - network
+                last_exc = exc
+            time.sleep(5)
+        else:
+            raise AssertionError(f"{base_url} never became healthy: {last_exc}")
+
+
+def test_single_writer_exclusivity_across_two_apps() -> None:
+    thread_id = f"e2e-lock-{uuid.uuid4().hex[:12]}"
+    run_id_a = f"A-{uuid.uuid4().hex}"
+    run_id_b = f"B-{uuid.uuid4().hex}"
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        # 1. App A enters and holds the lease.
+        future_a: Future[requests.Response] = pool.submit(_invoke, BASE_URL_A, thread_id, run_id_a)
+        try:
+            # 2. Wait until A is provably inside the locked section.
+            _wait_for_entered(BASE_URL_A, thread_id, run_id_a, timeout=90)
+
+            # 3. Now fire App B for the SAME thread — the lease is still held.
+            resp_b = _invoke(BASE_URL_B, thread_id, run_id_b)
+            assert resp_b.status_code == 409, (
+                f"App B expected 409 lock-conflict, got {resp_b.status_code}: {resp_b.text}"
+            )
+            assert "in use" in resp_b.text.lower(), resp_b.text
+
+            # 4. App A completes successfully.
+            resp_a = future_a.result(timeout=120)
+        finally:
+            # Never leak the worker if an assertion fails mid-flight.
+            future_a.cancel()
+
+    assert resp_a.status_code == 200, f"App A expected 200, got {resp_a.status_code}: {resp_a.text}"
+
+    # 5. Final checkpoint reflects exactly one run id — App A's. App B never wrote.
+    final = _get_state_values(BASE_URL_A, thread_id)
+    assert final.get("entered") == run_id_a, final
+    assert final.get("completed") == run_id_a, final
+    assert final.get("run_id") == run_id_a, final
+    assert run_id_b not in final.values(), f"App B's run id leaked into checkpoint: {final}"


### PR DESCRIPTION
## Context
Third of the lock-hardening series (after #384/#388 and #385/#389). The distributed correctness of `AzureBlobLeaseThreadLock` was only unit-tested; the real-Azure cert covered only single-instance health/invoke/stream. This adds the missing proof of the core value proposition: **two instances + same `thread_id` + concurrent invoke → only one execution mutates the checkpoint.**

> Stacked on #389 (#385). Base auto-retargets to `main` as the stack merges.

## Approach (Oracle-reviewed)
Deterministic, not a flaky "fire both simultaneously" race:
1. Start App A's invoke async — it enters the mutation section, writes an `entered` marker, then holds the lease for `E2E_LOCK_HOLD_SECONDS` (default 20).
2. Poll the shared checkpoint via the state endpoint until `entered == run_id_a` — proving A is inside the locked section and still holding the lease.
3. Only then fire App B with the same `thread_id`; assert **409**.
4. Let A finish (200); assert the final checkpoint holds **exactly one** run id (A's) — B never wrote.

The graph is deliberately two nodes (`enter` -> `hold`) so LangGraph checkpoints `entered` *before* the lease-holding sleep, making the marker observable.

## What changed
- **`examples/e2e_app/lock_graph.py`** (new): `e2e_lock_agent` with `AzureBlobCheckpointSaver`.
- **`examples/e2e_app/function_app.py`**: register `e2e_lock_agent` with an app-level `AzureBlobLeaseThreadLock`, guarded so the baseline `e2e_agent` cert stays resilient.
- **`infra/main.bicep`**: optional App B (own plan, shared storage) + pre-created lock/checkpoint containers.
- **`tests/e2e/test_langgraph_lock_e2e.py`** (new): the deterministic two-app race.
- **`.github/workflows/e2e-azure.yml`**: deploy/publish to App A + App B, pass both base URLs.

## Acceptance Checklist
- [x] e2e node writes `entered` (unique run id), holds the lease, then `completed` — using `AzureBlobLeaseThreadLock` + single-writer checkpointer
- [x] Deploys the app as two Function Apps sharing lock container + checkpoint storage
- [x] Concurrent same-`thread_id` requests → exactly one enters; loser gets documented 409
- [x] Final checkpoint reflects exactly one run id
- [x] Wired into `e2e-azure.yml`; skips when second base URL unset (unit runs never hit the network)
- [x] Coverage stays >= 95% (96.18%), lint + typecheck clean

## Out of scope
- Renewal transient-failure behavior (#384) — validated by fault-injection unit tests, not this cloud test.
- Forcing multi-instance via Consumption scale-out (rejected as non-deterministic).

## References
- Closes #386
- Follows #388 (#384), #389 (#385)