### PR TITLE
perf(locks): isolate per-lease renewal so one stuck renew() cannot block all leases

### DIFF
--- a/src/azure_functions_langgraph/locks/azure_blob.py
+++ b/src/azure_functions_langgraph/locks/azure_blob.py
@@ -47,6 +47,7 @@ Renewal resilience:
 
 from __future__ import annotations
 
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 import importlib
 import logging
@@ -101,6 +102,12 @@ _MAX_CONSECUTIVE_RENEWAL_FAILURES = 3
 # Deadline for join() when close() stops the renewal thread. Bounded so a
 # stuck Azure call cannot indefinitely block interpreter shutdown.
 _RENEWAL_SHUTDOWN_TIMEOUT = 5.0
+
+# Upper bound on renewal worker threads. Each renewal tick renews all active
+# leases concurrently through this pool so one slow/hung ``renew()`` call cannot
+# delay renewals for the other keys; the pool is bounded so a burst of tracked
+# leases (or several simultaneously hung calls) cannot spawn unbounded threads.
+_RENEWAL_MAX_WORKERS = 16
 
 # Azure error codes that mean the lease is *definitively* gone (as opposed to a
 # transient network/service failure that should be retried on the next tick).
@@ -283,6 +290,10 @@ class AzureBlobLeaseThreadLock:
         self._shutdown_event: threading.Event = threading.Event()
         self._renewal_thread: threading.Thread | None = None
         self._renewal_interval: float = 0.0
+        # Per-call client-side timeout for a single ``renew()`` and the pool used
+        # to run renewals concurrently. Both stay unset when auto-renewal is off.
+        self._renewal_call_timeout: float = 0.0
+        self._renewal_executor: ThreadPoolExecutor | None = None
 
         if lease_duration != _LEASE_DURATION_INFINITE and not auto_renew:
             warnings.warn(
@@ -301,6 +312,14 @@ class AzureBlobLeaseThreadLock:
 
         if self._auto_renew:
             self._renewal_interval = lease_duration / _LEASE_RENEWAL_FRACTION
+            # Bound each renew() by one renewal interval: a call still pending
+            # when the next tick is due is abandoned (counted as a transient
+            # failure) so a hung call never stalls the loop or later ticks.
+            self._renewal_call_timeout = self._renewal_interval
+            self._renewal_executor = ThreadPoolExecutor(
+                max_workers=_RENEWAL_MAX_WORKERS,
+                thread_name_prefix=f"azblob-lease-renew-{id(self):x}",
+            )
             self._renewal_thread = threading.Thread(
                 target=self._renewal_worker,
                 name=f"azblob-lease-renew-{id(self):x}",
@@ -433,35 +452,84 @@ class AzureBlobLeaseThreadLock:
     def _renew_all_once(self) -> None:
         """Renew every currently tracked lease exactly once.
 
-        Safe to call from any thread. Renewal failures are classified:
+        Safe to call from any thread. When auto-renewal is enabled the renewals
+        run **concurrently** on a bounded pool and each ``renew()`` call is
+        bounded by :attr:`_renewal_call_timeout`, so one slow or hung call
+        neither delays the other keys' renewals nor stalls later ticks. A call
+        still pending when its timeout elapses is treated as a transient
+        failure (the key is retried, then marked ``lost`` after
+        :data:`_MAX_CONSECUTIVE_RENEWAL_FAILURES` consecutive misses). When
+        auto-renewal is disabled (no pool) the renewals run sequentially.
+
+        Renewal failures are classified:
 
         * **Definitive lease-loss** (see :meth:`_is_definitive_lease_loss`):
           the entry is marked ``lost`` but kept locally occupied so the same
           process cannot reacquire the key until :meth:`release` runs.
-        * **Transient failure** (anything else): the entry is kept and its
-          ``consecutive_failures`` counter is incremented so the next tick
-          retries. Only after
+        * **Transient failure** (anything else, including a timed-out call):
+          the entry is kept and its ``consecutive_failures`` counter is
+          incremented so the next tick retries. Only after
           :data:`_MAX_CONSECUTIVE_RENEWAL_FAILURES` consecutive transient
           failures is the entry marked ``lost``.
 
         A successful renewal resets ``consecutive_failures`` to ``0``.
         """
         with self._active_leases_guard:
-            snapshot = list(self._active_leases.items())
+            snapshot = [
+                (key, state)
+                for key, state in self._active_leases.items()
+                if not state.lost
+            ]
+        if not snapshot:
+            return
+
+        executor = self._renewal_executor
+        if executor is None:
+            # No pool (auto_renew disabled) — renew sequentially in-thread.
+            for key, state in snapshot:
+                try:
+                    state.lease.renew()
+                except Exception as exc:  # noqa: BLE001 - classified below
+                    self._handle_renew_failure(key, state, exc)
+                else:
+                    self._record_renew_success(key, state)
+            return
+
+        futures: dict[Future[None], tuple[tuple[str, str], _LeaseState]] = {}
         for key, state in snapshot:
-            if state.lost:
-                # Already known gone; leave it for release() to clear.
-                continue
-            try:
-                state.lease.renew()
-            except Exception as exc:  # noqa: BLE001 - classified below
-                self._handle_renew_failure(key, state, exc)
+            future = executor.submit(state.lease.renew)
+            futures[future] = (key, state)
+        done, not_done = wait(futures, timeout=self._renewal_call_timeout)
+        for future in done:
+            key, state = futures[future]
+            renew_exc = future.exception()
+            if renew_exc is not None:
+                self._handle_renew_failure(key, state, renew_exc)
             else:
-                with self._active_leases_guard:
-                    if self._active_leases.get(key) is state:
-                        state.consecutive_failures = 0
-                        state.last_successful_renewal = time.monotonic()
-                        state.last_error = None
+                self._record_renew_success(key, state)
+        for future in not_done:
+            # Call exceeded the client-side timeout; abandon it and count the
+            # miss as a transient failure. The orphaned thread stays parked in
+            # the bounded pool until its renew() returns, and the key is marked
+            # lost after enough consecutive misses, so the leak is bounded.
+            key, state = futures[future]
+            self._handle_renew_failure(
+                key,
+                state,
+                TimeoutError(
+                    "lease renew() exceeded the client-side renewal timeout"
+                ),
+            )
+
+    def _record_renew_success(
+        self, key: tuple[str, str], state: _LeaseState
+    ) -> None:
+        """Reset failure tracking for a lease that just renewed successfully."""
+        with self._active_leases_guard:
+            if self._active_leases.get(key) is state:
+                state.consecutive_failures = 0
+                state.last_successful_renewal = time.monotonic()
+                state.last_error = None
 
     def _handle_renew_failure(
         self, key: tuple[str, str], state: _LeaseState, exc: BaseException
@@ -530,6 +598,11 @@ class AzureBlobLeaseThreadLock:
         thread = self._renewal_thread
         if thread is not None and thread.is_alive():
             thread.join(timeout=_RENEWAL_SHUTDOWN_TIMEOUT)
+        executor = self._renewal_executor
+        if executor is not None:
+            # Don't wait on in-flight renewals — a hung renew() must not block
+            # shutdown; cancel_futures drops any that never started running.
+            executor.shutdown(wait=False, cancel_futures=True)
         with self._active_leases_guard:
             remaining = list(self._active_leases.items())
             self._active_leases.clear()

--- a/tests/test_locks_azure_blob.py
+++ b/tests/test_locks_azure_blob.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 from typing import Any, Callable
@@ -869,3 +870,108 @@ class TestAutoRenewal:
         assert any(
             "during close" in rec.getMessage() for rec in caplog.records
         )
+
+
+class TestPerLeaseRenewalIsolation:
+    """#387 — one stuck renew() must not stall renewals for the other leases."""
+
+    def test_auto_renew_builds_bounded_executor_and_call_timeout(self) -> None:
+        """Enabling auto-renew wires a bounded pool and a per-call timeout."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        lock = _make_lock(lease_duration=30)
+        try:
+            assert isinstance(lock._renewal_executor, ThreadPoolExecutor)
+            # Client-side timeout bounds a single renew() to one renewal tick.
+            assert lock._renewal_call_timeout == pytest.approx(lock._renewal_interval)
+        finally:
+            lock.close()
+
+    def test_no_executor_when_auto_renew_disabled(self) -> None:
+        """Without auto-renew there is no pool; renewals run sequentially."""
+        lock = _make_lock(lease_duration=30, auto_renew=False)
+        try:
+            assert lock._renewal_executor is None
+            assert lock._renewal_call_timeout == 0.0
+        finally:
+            lock.close()
+
+    def test_hung_renew_does_not_block_other_leases(self) -> None:
+        """A hung renew() for key A must not stop key B renewing within the tick."""
+        container = MockContainerClient()
+        # auto_renew=True builds the concurrency pool; the background daemon only
+        # fires at lease_duration/3 (=20s), so it will not run during this test.
+        lock = _make_lock(container, lease_duration=60)
+        release_hung = threading.Event()
+        try:
+            # Shrink the per-call timeout so the hung call is abandoned quickly.
+            lock._renewal_call_timeout = 0.2
+            lock.acquire("graph", "hung")
+            lock.acquire("graph", "fast")
+            hung_state = lock._active_leases[("graph", "hung")]
+            fast_state = lock._active_leases[("graph", "fast")]
+
+            def _hang() -> None:
+                release_hung.wait(timeout=5.0)
+
+            hung_state.lease.renew = _hang
+
+            start = time.monotonic()
+            lock._renew_all_once()
+            elapsed = time.monotonic() - start
+
+            # The fast lease was renewed even though the other call is still hung,
+            assert fast_state.lease.renew_count == 1
+            assert fast_state.consecutive_failures == 0
+            assert fast_state.lost is False
+            # the tick returned near the client-side timeout, not the 5s hang,
+            assert elapsed < 2.0
+            # and the abandoned call was counted as one transient failure.
+            assert hung_state.consecutive_failures == 1
+            assert hung_state.lost is False
+        finally:
+            release_hung.set()
+            lock.close()
+
+    def test_repeated_renew_timeouts_mark_lease_lost(self) -> None:
+        """Enough consecutive timed-out renewals mark the lease lost."""
+        container = MockContainerClient()
+        lock = _make_lock(container, lease_duration=60)
+        release_hung = threading.Event()
+        try:
+            lock._renewal_call_timeout = 0.05
+            lock.acquire("graph", "hung")
+            state = lock._active_leases[("graph", "hung")]
+
+            def _hang() -> None:
+                release_hung.wait(timeout=5.0)
+
+            state.lease.renew = _hang
+
+            for _ in range(3):
+                lock._renew_all_once()
+            assert state.lost is True
+        finally:
+            release_hung.set()
+            lock.close()
+
+    def test_concurrent_path_records_immediate_renew_failure(self) -> None:
+        """A renew() that raises quickly on the pool is classified, not swallowed."""
+        container = MockContainerClient()
+        lock = _make_lock(container, lease_duration=60)
+        try:
+            lock.acquire("graph", "flaky")
+            state = lock._active_leases[("graph", "flaky")]
+
+            def _boom() -> None:
+                raise FakeHttpResponseError(
+                    "InternalError", error_code="InternalError", status_code=500
+                )
+
+            state.lease.renew = _boom
+            lock._renew_all_once()
+            # Transient failure recorded via the concurrent (pool) code path.
+            assert state.consecutive_failures == 1
+            assert state.lost is False
+        finally:
+            lock.close()


### PR DESCRIPTION
## Context
Closes #387 — the last issue in the lock-hardening series (#384 → #385 → #386 → #387). **Stacked on #390 (`fix/386-two-app-exclusivity-e2e`); review/merge that first.**

Previously the renewal daemon renewed every tracked lease **sequentially** in a single loop, so one slow or hung `renew()` call could delay — or entirely stall — renewals for every other key, risking silent lease expiry mid-execution.

## What changed
- Renew all active leases **concurrently** on a bounded `ThreadPoolExecutor` (`_RENEWAL_MAX_WORKERS = 16`).
- Bound each `renew()` with a client-side timeout of one renewal interval via `concurrent.futures.wait(timeout=...)`. A call still pending when the timeout elapses is abandoned and counted as a **transient failure** (retried, then marked `lost` after the usual consecutive-failure threshold) — so a hung call never stalls the loop or later ticks. The orphaned thread stays parked in the bounded pool, so the leak is bounded.
- Extracted `_record_renew_success` so the concurrent and sequential paths share success bookkeeping.
- Sequential fallback preserved for `auto_renew=False` (no pool).
- `close()` now shuts the pool down with `wait=False, cancel_futures=True` so a hung renew cannot block shutdown.

## Acceptance checklist
- [x] Bound each `renew()` with an explicit client-side timeout.
- [x] Slow/failing renewal for one key does not delay other keys (bounded concurrency + timeout-and-continue).
- [x] Unit test: a hung `renew()` for key A does not prevent key B renewing within its interval (`test_hung_renew_does_not_block_other_leases`), plus timeout-to-lost and concurrent-path failure coverage.
- [x] Coverage stays ≥ 95% (96.27% overall; `locks/azure_blob.py` 98%).
- [x] `make lint`, `make typecheck` clean.

## Out of scope
- Renewal transient-failure classification (#384).
- Owner-safe release (#385).