### PR TITLE
ci(dependabot): add maturation cooldown and pin artifact actions to v4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Let freshly-published versions age before Dependabot proposes them, so a
+    # compromised release has time to be yanked/flagged (supply-chain hardening).
+    # Cooldown applies to *version* updates only — Dependabot **security** updates
+    # bypass cooldown and stay on the fast path. See issue #381.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
     commit-message:
       prefix: "chore(deps)"
     labels:
@@ -21,6 +32,33 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Let freshly-published versions age before Dependabot proposes them, so a
+    # compromised release has time to be yanked/flagged (supply-chain hardening).
+    # Cooldown applies to *version* updates only — Dependabot **security** updates
+    # bypass cooldown and stay on the fast path. See issue #381.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
+    # actions/upload-artifact + actions/download-artifact are deliberately held
+    # as a v4 "canonical pair" (see tools/lint_release_workflows.py CANONICAL_ACTIONS).
+    # download-artifact v5+ raises the runner floor to Node 24 and flips
+    # digest-mismatch to fail-by-default, which would break the release-gate lint
+    # and the release-gate workflows. New majors are adopted deliberately, in
+    # lockstep, by updating those canonical SHAs together — not via an automatic
+    # Dependabot bump. Note: ignoring the major line also suppresses *major*
+    # security advisories for these two actions, so such advisories require
+    # deliberate manual review. See issue #334.
+    ignore:
+      - dependency-name: "actions/upload-artifact"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "actions/download-artifact"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "chore(deps)"
     labels:


### PR DESCRIPTION
## Context
Supersedes #383 (whose `build/…` branch failed `branch-naming-validation`) and folds in #334, since both changes touch the same `.github/dependabot.yml` surface. Part of the toolkit-wide supply-chain hardening pass.

## Changes
- **#381 — maturation cooldown.** Add `cooldown:` to both the `pip` and `github-actions` ecosystems (major 30d, minor 7d, patch 3d, default 7d). Dependabot now waits for a version to age before opening a PR, so a compromised upstream release has time to be yanked/flagged before the existing `dependabot-automerge.yml` auto-merges patch/minor bumps. Cooldown applies to **version** updates only — **security** updates bypass it and stay on the fast path.
- **#334 — v4 canonical pin.** `ignore` major (`version-update:semver-major`) bumps for `actions/upload-artifact` and `actions/download-artifact`, keeping them on the v4 canonical pair enforced by `tools/lint_release_workflows.py` (`CANONICAL_ACTIONS`). This makes the existing code comment there — "Dependabot is configured to ignore major bumps for both" — actually true. `download-artifact` v5+ raises the runner floor to Node 24 and flips digest-mismatch to fail-by-default, which would break the release-gate lint; new majors are adopted deliberately in lockstep. The rationale comment notes that ignoring the major line also suppresses **major** security advisories for these two actions, so those require deliberate manual review.

Stale bump PRs #329 / #330 are already **closed**.

## Acceptance
### #381
- [x] Maturation cooldown before auto-merge (native `cooldown:` in `.github/dependabot.yml`).
- [x] Security updates stay on the fast path (cooldown does not apply to security updates — documented inline).
- [x] `make lint` / workflow-pin lint pass.

### #334
- [x] Keep artifact actions on the v4 canonical pair (`ignore` major bumps); #329/#330 already closed.
- [x] v4-canonical-pin rationale documented next to the release-gate lint config (`tools/lint_release_workflows.py`) and cross-referenced from `dependabot.yml`.
- [ ] Remove the `github-actions` ecosystem once Renovate is confirmed as the actions manager — **intentionally deferred** (Renovate not yet confirmed; removing now would leave that surface unmanaged).

## Validation
- `python3 tools/lint_release_workflows.py` → canonical ✔
- `python3 tools/lint_workflow_pins.py` → pin-hygiene ✔
- `make lint` → All checks passed ✔
- `dependabot.yml` parses as valid YAML; both ecosystems carry `cooldown`, github-actions carries the two `ignore` rules.

Closes #381
Closes #334