### PR TITLE
ci(release): scope cross-repo dispatch token to least privilege

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -274,18 +274,26 @@ jobs:
     name: Trigger cookbook e2e re-verification
     needs: [build, publish]
     runs-on: ubuntu-latest
-    env:
-      # Cross-repo repository_dispatch needs a token with contents:write on the
-      # cookbook repo (GITHUB_TOKEN cannot cross repositories). Supply a PAT or
-      # GitHub App token via the COOKBOOK_DISPATCH_TOKEN secret. When it is unset
-      # the step is skipped, so missing wiring never fails a release.
-      DISPATCH_TOKEN: ${{ secrets.COOKBOOK_DISPATCH_TOKEN }}
+    permissions:
+      contents: read
+    timeout-minutes: 5
     steps:
       - name: Dispatch sibling-release to cookbook
-        if: ${{ env.DISPATCH_TOKEN != '' }}
         env:
+          # Cross-repo repository_dispatch needs a token with contents:write on
+          # the cookbook repo (GITHUB_TOKEN cannot cross repositories). Supply a
+          # fine-grained PAT or GitHub App installation token scoped to
+          # azure-functions-cookbook-python contents:write via the
+          # COOKBOOK_DISPATCH_TOKEN secret. Scoped to this step so no other step
+          # in the job can read it. When it is unset the step no-ops below, so
+          # missing wiring never fails a release.
+          DISPATCH_TOKEN: ${{ secrets.COOKBOOK_DISPATCH_TOKEN }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
+          if [ -z "${DISPATCH_TOKEN}" ]; then
+            echo "COOKBOOK_DISPATCH_TOKEN not set; skipping cross-repo dispatch."
+            exit 0
+          fi
           curl -sSf -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \


### PR DESCRIPTION
## Summary
Hardens the `notify-cookbook` job in `publish-pypi.yml` (the cross-repo `repository_dispatch` that fires the cookbook e2e re-verification) to least privilege — the in-workflow portion of #382.

## Changes
- **Job-level `permissions: contents: read`** — the job previously inherited the workflow-level token scope; it now declares the minimal scope it needs (the cross-repo call authenticates with `COOKBOOK_DISPATCH_TOKEN`, not `GITHUB_TOKEN`).
- **`timeout-minutes: 5`** — bounds the dispatch step, matching the `verify-azure-certification` and `publish` jobs.
- **Secret scoped to the step** — `COOKBOOK_DISPATCH_TOKEN` moved from job `env` to the dispatch step `env`, so no other step in the job can read it.
- **In-shell empty-token skip** — replaces the job-env `if:` guard; a missing/unset token logs and `exit 0`s, so absent wiring still never fails a release.

## Verification
- `python3 tools/lint_workflow_pins.py` ✔
- `python3 tools/lint_release_workflows.py` ✔ (pins and publish gate still canonical)
- `make lint` ✔
- YAML parses clean.

## Out of scope (repo-admin actions, tracked on the issue, left open)
- Auditing the actual scope of the `COOKBOOK_DISPATCH_TOKEN` secret.
- Cutting over to a fine-grained PAT / GitHub App installation token scoped to `azure-functions-cookbook-python` `contents:write`.
- Rotating the old token after cutover.

These are performed in GitHub repo settings and cannot be done from source, so this PR uses `Refs #382` rather than `Closes`.

Refs #382