### PR TITLE
docs(stream): establish true-streaming tracker and link #378

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -171,6 +171,55 @@ src/azure_functions_langgraph/
 - Coverage threshold enforced at 95% (`fail_under = 95`)
 
 
+## Streaming: buffered SSE and the true-streaming migration (#378)
+
+The `/stream` endpoints — native `POST /api/graphs/{name}/stream` and the
+Platform-compatible `POST /threads/{id}/runs/stream` and `POST /runs/stream` —
+return **buffered** SSE. Chunks emitted by the graph are collected during
+execution and flushed as SSE events *after the run completes*; clients never
+receive partial tokens incrementally. This is a deliberate design choice, not a
+bug and not an Azure platform limitation. It is tracked for future migration in
+[issue #378](https://github.com/yeongseon/azure-functions-langgraph-python/issues/378).
+
+### Why buffered today
+
+This package registers **classic** `HttpRequest`/`HttpResponse` routes via the
+Azure Functions Python v2 `FunctionApp` programming model. In that model a
+handler returns a single, fully-formed `HttpResponse`, so the SSE body must be
+assembled in memory before it is returned. `max_stream_response_bytes` is only a
+safety cap on that in-memory buffer — it does not enable incremental delivery.
+
+### The concrete constraint
+
+Azure Functions Python *does* support true HTTP streaming (runtime **4.34.1+**)
+through the `azurefunctions-extensions-http-fastapi` extension. That extension
+switches the **entire function app** to the FastAPI/ASGI model: routes become
+ASGI routes served by a FastAPI/Starlette app rather than classic
+`HttpRequest`/`HttpResponse` handlers. The two models **cannot be mixed** within
+one function app, so adopting true streaming is an app-wide architectural change,
+not a per-endpoint toggle.
+
+### Design questions for the migration (tracked in #378)
+
+- **Opt-in coexistence.** Can true streaming be offered as an opt-in — e.g. a
+  dedicated ASGI sub-app or a separate streaming entrypoint — without forcing
+  every consumer of this package onto the ASGI model? If not, the migration is a
+  breaking change gated on a major version.
+- **Breaking-change surface.** Moving to ASGI re-touches route registration,
+  per-graph `auth_level` handling (Functions auth vs. ASGI middleware), the
+  health endpoints, and the native-endpoint per-thread locking — each must be
+  re-established under the FastAPI/ASGI model.
+- **Streaming semantics.** Under true streaming, `stream_mode`, backpressure, and
+  the meaning of `max_stream_response_bytes` (a hard buffer cap today) all need
+  redefinition — likely a soft flush threshold or removal.
+- **Release promise.** Core (classic, buffered) vs. Platform-compat streaming
+  guarantees must stay separable so the buffered contract does not silently
+  change under existing users.
+
+Actual implementation of the ASGI migration is **out of scope for #378** — that
+issue establishes the tracker and the design constraints; implementation follows
+in a dedicated issue/PR once an approach is agreed.
+
 ## Sources
 
 - [Azure Functions Python developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -240,8 +240,10 @@ def handle_stream(
 
     Returns a **buffered** SSE-formatted response.  All stream chunks are
     collected first, then returned in a single HTTP response.  This is a
-    known v0.1 limitation — true chunked streaming will follow once Azure
-    Functions Python HTTP streaming is fully stable.
+    known v0.1 limitation, tracked in issue #378 — true chunked streaming will
+    follow once Azure Functions Python HTTP streaming is fully stable. See the
+    "Streaming: buffered SSE and the true-streaming migration" section of
+    ``DESIGN.md`` for the constraints and migration path.
     """
     if not reg.stream_enabled:
         return _error_response(501, f"Graph {reg.name!r} is configured as invoke-only")

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -174,7 +174,8 @@ class LangGraphApp:
         ``azurefunctions-extensions-http-fastapi`` ASGI extension, but enabling
         it switches the entire function app to the FastAPI/ASGI model, which
         cannot be mixed with the classic routes used here — an app-wide
-        architectural change tracked separately.
+        architectural change tracked in issue #378 (see the "Streaming:
+        buffered SSE and the true-streaming migration" section of ``DESIGN.md``).
 
     Note:
         The default ``auth_level`` is :attr:`~azure.functions.AuthLevel.FUNCTION`,


### PR DESCRIPTION
## Summary
Closes the documentation-integrity gap flagged by #378: the `handle_stream()` and `register()` docstrings described the buffered-SSE behaviour as "tracked separately" while no backing issue existed. #378 is now that tracker; this PR wires the docs to it and records the design constraints.

## Changes
- **`DESIGN.md`** — new section *"Streaming: buffered SSE and the true-streaming migration (#378)"* covering all four design acceptance items:
  - the concrete constraint (`azurefunctions-extensions-http-fastapi` needs runtime 4.34.1+ and switches the **entire app** to FastAPI/ASGI, incompatible with the classic `HttpRequest`/`HttpResponse` routes this package registers);
  - whether true streaming can be **opt-in** (dedicated ASGI sub-app / separate entrypoint) vs. a major-version breaking change;
  - the migration/coexistence **breaking-change surface** (route registration, per-graph auth levels, health endpoints, per-thread locking);
  - **streaming semantics** (`stream_mode`, backpressure, `max_stream_response_bytes` behaviour under true streaming).
- **`app.py`** / **`_handlers.py`** — docstrings now link issue #378 and `DESIGN.md` instead of "tracked separately".

## Out of scope
Actually implementing the ASGI migration — #378 establishes the tracker and constraints only; implementation follows in a dedicated issue/PR.

## Verification
- `make lint` ✔ (ruff + mypy, 69 source files clean)
- Docstring/doc-only changes; no runtime behaviour change.

Closes #378