### PR TITLE
fix(checkpointers): make blob version suffix deterministic

### DIFF
--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -168,7 +168,10 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
             current_v = int(current.split(".")[0])
         next_v = current_v + 1
         next_h = random.random()  # nosec B311 - non-crypto ordering/uniqueness only
-        return f"{next_v:032}.{next_h:016}"
+        # Fixed 16-decimal precision keeps the suffix a stable ``0.<digits>`` shape.
+        # A bare ``:016`` width spec left-zero-pads short reprs (e.g. ``0.5`` ->
+        # ``0000000000000.5``), which is inconsistent and non-deterministic. See #397.
+        return f"{next_v:032}.{next_h:.16f}"
 
     def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Fetch a checkpoint tuple by config or latest checkpoint hint."""

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -274,12 +274,18 @@ def test_get_next_version(
 ) -> None:
     saver, _ = saver_and_container
 
-    version_1 = saver.get_next_version(None, None)
-    version_2 = saver.get_next_version(version_1, None)
-
-    assert re.fullmatch(r"\d{32}\.0\.\d+", version_1) is not None
-    assert re.fullmatch(r"\d{32}\.0\.\d+", version_2) is not None
-    assert int(version_2.split(".", maxsplit=1)[0]) == int(version_1.split(".", maxsplit=1)[0]) + 1
+    # Exercise many random draws so a regression to the non-deterministic
+    # zero-padded suffix (see #397) is caught reliably, not intermittently.
+    previous = saver.get_next_version(None, None)
+    assert re.fullmatch(r"\d{32}\.0\.\d+", previous) is not None
+    for _ in range(1000):
+        current = saver.get_next_version(previous, None)
+        assert re.fullmatch(r"\d{32}\.0\.\d+", current) is not None
+        assert (
+            int(current.split(".", maxsplit=1)[0])
+            == int(previous.split(".", maxsplit=1)[0]) + 1
+        )
+        previous = current
 
 
 def test_put_and_get_tuple(


### PR DESCRIPTION
## Summary
- Fixes the intermittent CI failure in `test_get_next_version` (#397).
- `AzureBlobCheckpointSaver.get_next_version` formatted the random tiebreaker suffix with a bare `:016` **width** spec, which left-zero-pads short `random.random()` reprs (e.g. `0.5` → `0000000000000.5`). The test's `\d{32}\.0\.\d+` regex only matched when the draw's repr happened to be ≥16 chars — a genuine flake.
- Switch to fixed 16-decimal precision (`:.16f`) so the suffix is always `0.<16 digits>`.
- Harden the test to loop across **1000** random draws so a regression is caught deterministically.

## Safety
- The monotonic ordering contract (the 32-digit zero-padded prefix consumed via `int(version.split(".")[0])`) is **unchanged** — only the tiebreaker suffix formatting changed.

## Verification
- `make lint` ✔ (ruff + mypy, 70 files)
- Full suite ✔ — **1045 passed**, coverage **96.27% ≥ 95%**

Closes #397