### PR TITLE
docs(examples): add deployable Azure OpenAI LangGraph agent example (#402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ pip install -e .[dev]
 
 > **New to this package?** Follow the [**Deploy a LangGraph agent to Azure Functions in 5 minutes**](docs/tutorial-5-min.md) tutorial — a genuinely runnable, CI-smoke-tested walkthrough from a compiled graph to live HTTP endpoints, locally and on Azure.
 
+> **Want a real agent, not an echo?** After the Quick Start, jump to the [**Azure OpenAI agent example**](examples/azure_openai_agent/) — a deployable LangGraph agent backed by a real Azure OpenAI deployment, with API-key and Managed Identity paths.
+
 ```python
 from langgraph.graph import END, START, StateGraph
 from typing_extensions import TypedDict

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,8 @@
 
 | Role | Path | Description |
 | --- | --- | --- |
-| Minimal | [`simple_agent`](simple_agent/) | Two-node greeting agent with sequential edges. |
+| Minimal | [`simple_agent`](simple_agent/) | Two-node greeting agent with sequential edges (deterministic, no LLM). |
+| **Real agent — start here** | [`azure_openai_agent`](azure_openai_agent/) ⭐ | **Recommended after Quick Start.** LangGraph agent backed by a real Azure OpenAI deployment; API-key and Managed Identity paths, deterministic fake-model fallback for CI. |
 | Platform SDK | [`platform_compat_sdk`](platform_compat_sdk/) ⭐ | `platform_compat=True` host driven by the official `langgraph-sdk` client. |
 | Persistent storage | [`persistent_agent_blob_table`](persistent_agent_blob_table/) | End-to-end Azure Blob checkpointer + Azure Table thread store, runnable on Azurite. |
 | DB checkpoint (local) | [`sqlite_checkpoint_local`](sqlite_checkpoint_local/) | LangGraph SQLite checkpointer wired via `create_sqlite_checkpointer()` for local dev. |
@@ -31,7 +32,8 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 
 ## Picking an example
 
-- **Just want it running?** → `simple_agent`
+- **Just want it running (no LLM)?** → `simple_agent`
+- **Want a real Azure OpenAI agent? (start here after Quick Start)** → `azure_openai_agent`
 - **Switching from LangGraph Cloud / using `langgraph-sdk`?** → `platform_compat_sdk`
 - **Need state to survive restarts and scale-out?** → `persistent_agent_blob_table`
 - **Deploying to Azure with Managed Identity (no secrets in App Settings)?** → `managed_identity_storage`

--- a/examples/azure_openai_agent/README.md
+++ b/examples/azure_openai_agent/README.md
@@ -111,8 +111,9 @@ Identity in production — do not store the key in App Settings).
 
 ## CI / credential-free runs
 
-When `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_DEPLOYMENT` are unset, `graph.py`
-builds a deterministic `GenericFakeChatModel` instead of calling Azure OpenAI.
+Unless Azure OpenAI is **fully** configured — endpoint, deployment, **and** an
+auth method (`AZURE_OPENAI_API_KEY`, or `AZURE_OPENAI_USE_ENTRA_ID=true`) —
+`graph.py` builds a deterministic `GenericFakeChatModel` instead of calling Azure OpenAI.
 This keeps the example importable and smoke-testable in CI without any cloud
 credentials, and the fake path never imports `langchain_openai`. Configure the
 `AZURE_OPENAI_*` variables to use a real deployment.

--- a/examples/azure_openai_agent/README.md
+++ b/examples/azure_openai_agent/README.md
@@ -1,0 +1,118 @@
+# Azure OpenAI Agent Example
+
+**Start here after the Quick Start.** This is the primary real-world example: a
+minimal LangGraph agent backed by a **real Azure OpenAI** chat deployment,
+deployed as Azure Functions HTTP endpoints.
+
+The package stays a *deployment adapter* — `graph.py` is a normal LangGraph
+`StateGraph`, and `function_app.py` only calls `register()`:
+
+```python
+# function_app.py
+app = LangGraphApp()
+app.register(graph=compiled_graph, name="azure_openai_agent")
+func_app = app.function_app
+```
+
+> **Why not `simple_agent`?** [`simple_agent`](../simple_agent/) stays
+> deterministic (echo, no LLM) so it can be smoke-tested without a model. This
+> example uses a real Azure OpenAI deployment so you can evaluate the package
+> against an actual agent. When Azure OpenAI is **not** configured, this graph
+> falls back to a deterministic fake model (see [CI note](#ci--credential-free-runs)).
+
+## Prerequisites
+
+- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) v4+
+- Python 3.10+
+- An **Azure OpenAI** resource with a **chat model deployment** (e.g. `gpt-4o-mini`)
+
+## Configuration
+
+Copy the settings template and fill in your Azure OpenAI values:
+
+```bash
+cd examples/azure_openai_agent
+cp local.settings.json.example local.settings.json
+```
+
+| Environment variable | Required | Description |
+| --- | --- | --- |
+| `AZURE_OPENAI_ENDPOINT` | Yes | e.g. `https://<resource>.openai.azure.com/` |
+| `AZURE_OPENAI_DEPLOYMENT` | Yes | Your chat deployment name |
+| `AZURE_OPENAI_API_VERSION` | No | Defaults to `2024-10-21` |
+| `AZURE_OPENAI_API_KEY` | API-key path | The resource key |
+| `AZURE_OPENAI_USE_ENTRA_ID` | Entra ID path | Set `true` and leave the key unset |
+
+### Authentication paths
+
+1. **API key (easiest local onboarding).** Set `AZURE_OPENAI_API_KEY`.
+2. **Managed Identity / Entra ID (recommended for Azure production).** Leave
+   `AZURE_OPENAI_API_KEY` unset and set `AZURE_OPENAI_USE_ENTRA_ID=true`. The
+   model authenticates with `DefaultAzureCredential` and the
+   `https://cognitiveservices.azure.com/.default` scope — the Function App's
+   Managed Identity in Azure, or `az login` locally. No secret lands in App
+   Settings.
+
+   Grant the identity the **Cognitive Services OpenAI User** role on the Azure
+   OpenAI resource.
+
+## Run locally
+
+```bash
+pip install -r requirements.txt
+func start
+```
+
+## Test
+
+```bash
+# Invoke the agent (native endpoint — the package's primary route)
+curl -X POST http://localhost:7071/api/graphs/azure_openai_agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"messages": [{"role": "human", "content": "What is Azure Functions in one sentence?"}]}}'
+
+# Health check
+curl http://localhost:7071/api/health
+```
+
+Expected response shape (model text is illustrative and nondeterministic):
+
+```json
+{
+  "output": {
+    "messages": [
+      {"content": "What is Azure Functions in one sentence?", "type": "human", "...": "..."},
+      {"content": "Azure Functions is a serverless compute service that runs event-driven code without managing infrastructure.", "type": "ai", "...": "..."}
+    ]
+  }
+}
+```
+
+> The response envelope is `{"output": <graph result>}`. Because this graph uses
+> LangGraph's `add_messages` state, each item in `messages` is a **serialized
+> LangChain message** (fields such as `content`, `type`, `additional_kwargs`,
+> `response_metadata`, `id`), not a bare `{"role", "content"}` pair. The exact
+> fields and the assistant text vary per model response.
+
+## Deploy to Azure
+
+Application code does not change between local and Azure. Follow the canonical
+[deployment guide](../../docs/deployment.md), then set the same
+`AZURE_OPENAI_*` values as **Function App application settings** (use Managed
+Identity in production — do not store the key in App Settings).
+
+> **Production auth:** `LangGraphApp` defaults to `AuthLevel.FUNCTION`, so the
+> deployed invoke endpoint requires a function key
+> (`?code=<FUNCTION_KEY>` or the `x-functions-key` header).
+
+> **Cost:** this example invokes a **billable** Azure OpenAI deployment. Each
+> request to the invoke endpoint consumes tokens against your Azure OpenAI
+> quota.
+
+## CI / credential-free runs
+
+When `AZURE_OPENAI_ENDPOINT` / `AZURE_OPENAI_DEPLOYMENT` are unset, `graph.py`
+builds a deterministic `GenericFakeChatModel` instead of calling Azure OpenAI.
+This keeps the example importable and smoke-testable in CI without any cloud
+credentials, and the fake path never imports `langchain_openai`. Configure the
+`AZURE_OPENAI_*` variables to use a real deployment.

--- a/examples/azure_openai_agent/function_app.py
+++ b/examples/azure_openai_agent/function_app.py
@@ -9,7 +9,7 @@ from graph import compiled_graph
 from azure_functions_langgraph import LangGraphApp
 
 # Default auth_level is AuthLevel.FUNCTION — deployed endpoints require a
-# function key. See README for the anonymous local-dev opt-in.
+# function key (`?code=<FUNCTION_KEY>` or the `x-functions-key` header).
 langgraph_app = LangGraphApp()
 langgraph_app.register(
     graph=compiled_graph,

--- a/examples/azure_openai_agent/function_app.py
+++ b/examples/azure_openai_agent/function_app.py
@@ -1,0 +1,20 @@
+"""Azure OpenAI agent - Azure Functions entry point.
+
+Run from this directory:
+    func start
+"""
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+
+# Default auth_level is AuthLevel.FUNCTION — deployed endpoints require a
+# function key. See README for the anonymous local-dev opt-in.
+langgraph_app = LangGraphApp()
+langgraph_app.register(
+    graph=compiled_graph,
+    name="azure_openai_agent",
+    description="A concise Azure cloud assistant backed by an Azure OpenAI chat deployment",
+)
+
+app = langgraph_app.function_app

--- a/examples/azure_openai_agent/graph.py
+++ b/examples/azure_openai_agent/graph.py
@@ -1,0 +1,154 @@
+"""Azure OpenAI LangGraph agent deployed as Azure Functions.
+
+This is the **primary real-world example**: a minimal but genuinely useful
+LangGraph agent backed by a real Azure OpenAI chat deployment, exposed over
+HTTP by ``LangGraphApp`` with zero adapter-specific abstractions.
+
+The package stays a *deployment adapter* — everything below is a normal
+LangGraph ``StateGraph``. ``function_app.py`` only calls ``register()``.
+
+Authentication (resolved at model-construction time):
+
+1. **API key** — set ``AZURE_OPENAI_API_KEY`` (easiest local onboarding).
+2. **Managed Identity / Entra ID** — leave the key unset and set
+   ``AZURE_OPENAI_USE_ENTRA_ID=true``; the model authenticates with
+   ``DefaultAzureCredential`` (Function App Managed Identity in Azure,
+   ``az login`` locally). No secret lands in App Settings.
+
+Both paths require ``AZURE_OPENAI_ENDPOINT`` and ``AZURE_OPENAI_DEPLOYMENT``.
+
+When Azure OpenAI is **not** configured (no endpoint), the graph falls back to
+a deterministic in-process fake model so the example imports, compiles, and can
+be smoke-tested in CI without any cloud credentials. The fake path never
+imports ``langchain_openai``.
+
+Requirements::
+
+    pip install azure-functions-langgraph langgraph langchain-core langchain-openai azure-identity
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+from typing import Annotated, Any
+
+from typing_extensions import TypedDict
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+SYSTEM_PROMPT = (
+    "You are a concise Azure cloud assistant. Answer questions about Azure, "
+    "serverless architecture, and LangGraph clearly and briefly. If you are "
+    "unsure, say so rather than guessing."
+)
+
+# Azure OpenAI configuration (read at import / cold start).
+_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT")
+_DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY")
+# langchain-openai / openai default to reading OPENAI_API_VERSION; we surface an
+# explicit, currently-supported default so the example is not tied to whatever
+# happens to be in the environment.
+_API_VERSION = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-10-21")
+_USE_ENTRA_ID = os.environ.get("AZURE_OPENAI_USE_ENTRA_ID", "").strip().lower() in _TRUTHY
+
+
+def _azure_configured() -> bool:
+    """True when enough config is present to build a real Azure OpenAI model."""
+    return bool(_ENDPOINT and _DEPLOYMENT and (_API_KEY or _USE_ENTRA_ID))
+
+
+def build_chat_model() -> Any:
+    """Construct the chat model for the agent.
+
+    Returns a real ``AzureChatOpenAI`` when Azure OpenAI is configured, else a
+    deterministic fake model for credential-free local runs and CI.
+    """
+    if _azure_configured():
+        # Import lazily so the fake path never requires langchain-openai.
+        from langchain_openai import AzureChatOpenAI
+
+        if _USE_ENTRA_ID and not _API_KEY:
+            # Managed Identity / Entra ID path. DefaultAzureCredential picks up
+            # the Function App's Managed Identity in Azure and `az login`
+            # locally — the same code path works in both environments.
+            from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+
+            token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(),
+                "https://cognitiveservices.azure.com/.default",
+            )
+            return AzureChatOpenAI(
+                azure_endpoint=_ENDPOINT,
+                azure_deployment=_DEPLOYMENT,
+                api_version=_API_VERSION,
+                azure_ad_token_provider=token_provider,
+            )
+
+        # API-key path.
+        return AzureChatOpenAI(
+            azure_endpoint=_ENDPOINT,
+            azure_deployment=_DEPLOYMENT,
+            api_version=_API_VERSION,
+            api_key=_API_KEY,
+        )
+
+    # Deterministic fallback — no cloud, no secrets, no langchain-openai.
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.messages import AIMessage
+
+    canned = AIMessage(
+        content=(
+            "[fake model] Azure OpenAI is not configured. Set AZURE_OPENAI_ENDPOINT, "
+            "AZURE_OPENAI_DEPLOYMENT, and AZURE_OPENAI_API_KEY (or "
+            "AZURE_OPENAI_USE_ENTRA_ID=true) to use a real deployment."
+        )
+    )
+    # itertools.cycle → the fake never exhausts across repeated invocations.
+    return GenericFakeChatModel(messages=itertools.cycle([canned]))
+
+
+# ------------------------------------------------------------------
+# 1. Define state (LangGraph's standard message-state pattern)
+# ------------------------------------------------------------------
+try:
+    from langgraph.graph import END, START, StateGraph
+    from langgraph.graph.message import add_messages
+
+    class AgentState(TypedDict):
+        messages: Annotated[list, add_messages]
+
+    # Built once at cold start; reused across invocations.
+    _model = build_chat_model()
+
+    # ------------------------------------------------------------------
+    # 2. Define node functions
+    # ------------------------------------------------------------------
+    def chat(state: AgentState) -> dict[str, Any]:
+        """Single agent node: prepend the system prompt and call the model."""
+        from langchain_core.messages import SystemMessage
+
+        response = _model.invoke([SystemMessage(content=SYSTEM_PROMPT), *state["messages"]])
+        return {"messages": [response]}
+
+    # ------------------------------------------------------------------
+    # 3. Build the graph (normal LangGraph API — no adapter abstractions)
+    # ------------------------------------------------------------------
+    builder = StateGraph(AgentState)
+    builder.add_node("chat", chat)
+    builder.add_edge(START, "chat")
+    builder.add_edge("chat", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError as exc:  # pragma: no cover - defensive import guard
+    raise ImportError(
+        "langgraph and langchain-core are required for this example. Install with: "
+        "pip install azure-functions-langgraph langgraph langchain-core langchain-openai azure-identity"
+    ) from exc

--- a/examples/azure_openai_agent/graph.py
+++ b/examples/azure_openai_agent/graph.py
@@ -17,10 +17,10 @@ Authentication (resolved at model-construction time):
 
 Both paths require ``AZURE_OPENAI_ENDPOINT`` and ``AZURE_OPENAI_DEPLOYMENT``.
 
-When Azure OpenAI is **not** configured (no endpoint), the graph falls back to
-a deterministic in-process fake model so the example imports, compiles, and can
-be smoke-tested in CI without any cloud credentials. The fake path never
-imports ``langchain_openai``.
+When Azure OpenAI is **not** fully configured (no endpoint, no deployment, or no
+auth method), the graph falls back to a deterministic in-process fake model so
+the example imports, compiles, and can be smoke-tested in CI without any cloud
+credentials. The fake path never imports ``langchain_openai``.
 
 Requirements::
 
@@ -120,35 +120,39 @@ def build_chat_model() -> Any:
 try:
     from langgraph.graph import END, START, StateGraph
     from langgraph.graph.message import add_messages
-
-    class AgentState(TypedDict):
-        messages: Annotated[list, add_messages]
-
-    # Built once at cold start; reused across invocations.
-    _model = build_chat_model()
-
-    # ------------------------------------------------------------------
-    # 2. Define node functions
-    # ------------------------------------------------------------------
-    def chat(state: AgentState) -> dict[str, Any]:
-        """Single agent node: prepend the system prompt and call the model."""
-        from langchain_core.messages import SystemMessage
-
-        response = _model.invoke([SystemMessage(content=SYSTEM_PROMPT), *state["messages"]])
-        return {"messages": [response]}
-
-    # ------------------------------------------------------------------
-    # 3. Build the graph (normal LangGraph API — no adapter abstractions)
-    # ------------------------------------------------------------------
-    builder = StateGraph(AgentState)
-    builder.add_node("chat", chat)
-    builder.add_edge(START, "chat")
-    builder.add_edge("chat", END)
-
-    compiled_graph = builder.compile()
-
 except ImportError as exc:  # pragma: no cover - defensive import guard
     raise ImportError(
         "langgraph and langchain-core are required for this example. Install with: "
         "pip install azure-functions-langgraph langgraph langchain-core langchain-openai azure-identity"
     ) from exc
+
+
+class AgentState(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+# Built once at cold start; reused across invocations. Azure/langchain-openai
+# import errors (if that path is configured) propagate with their own message.
+_model = build_chat_model()
+
+
+# ------------------------------------------------------------------
+# 2. Define node functions
+# ------------------------------------------------------------------
+def chat(state: AgentState) -> dict[str, Any]:
+    """Single agent node: prepend the system prompt and call the model."""
+    from langchain_core.messages import SystemMessage
+
+    response = _model.invoke([SystemMessage(content=SYSTEM_PROMPT), *state["messages"]])
+    return {"messages": [response]}
+
+
+# ------------------------------------------------------------------
+# 3. Build the graph (normal LangGraph API — no adapter abstractions)
+# ------------------------------------------------------------------
+builder = StateGraph(AgentState)
+builder.add_node("chat", chat)
+builder.add_edge(START, "chat")
+builder.add_edge("chat", END)
+
+compiled_graph = builder.compile()

--- a/examples/azure_openai_agent/host.json
+++ b/examples/azure_openai_agent/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/azure_openai_agent/local.settings.json.example
+++ b/examples/azure_openai_agent/local.settings.json.example
@@ -1,0 +1,17 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+
+    "AZURE_OPENAI_ENDPOINT": "https://<your-resource>.openai.azure.com/",
+    "AZURE_OPENAI_DEPLOYMENT": "<your-chat-deployment-name>",
+    "AZURE_OPENAI_API_VERSION": "2024-10-21",
+
+    "_comment_apikey": "API-key path: set the key below (easiest local onboarding).",
+    "AZURE_OPENAI_API_KEY": "<your-azure-openai-key>",
+
+    "_comment_entra": "Managed Identity / Entra ID path: unset AZURE_OPENAI_API_KEY above and set the flag below instead.",
+    "AZURE_OPENAI_USE_ENTRA_ID": "false"
+  }
+}

--- a/examples/azure_openai_agent/requirements.txt
+++ b/examples/azure_openai_agent/requirements.txt
@@ -1,0 +1,13 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+#
+# langchain-openai + azure-identity are example-only dependencies. They are NOT
+# part of the base azure-functions-langgraph install — the package stays a
+# deployment adapter and does not pull in model SDKs.
+
+azure-functions
+azure-functions-langgraph>=0.8,<0.9
+langgraph>=1.0,<2.0
+langchain-core>=1.0,<2.0
+langchain-openai>=0.3,<1.0
+azure-identity>=1.19,<2.0

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -10,6 +10,7 @@ EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
 
 GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("simple_agent", "compiled_graph"),
+    ("azure_openai_agent", "compiled_graph"),
     ("platform_compat_sdk", "compiled_graph"),
     ("openapi_bridge", "compiled_graph"),
     ("production_auth", "private_graph"),
@@ -57,6 +58,7 @@ REQUIRED_FILES = (
 
 EXAMPLE_DIRS = (
     "simple_agent",
+    "azure_openai_agent",
     "platform_compat_sdk",
     "persistent_agent_blob_table",
     "managed_identity_storage",


### PR DESCRIPTION
## Summary
- Adds `examples/azure_openai_agent/` — the **primary real-world example**: a minimal LangGraph agent backed by a **real Azure OpenAI** chat deployment, exposed via `LangGraphApp` with no adapter-specific abstractions (`graph.py` is a normal `StateGraph`; `function_app.py` only calls `register()`).
- Documents **two auth paths**: API key (easiest local onboarding) and **Managed Identity / Entra ID** (`DefaultAzureCredential` + `get_bearer_token_provider` with scope `https://cognitiveservices.azure.com/.default`, passed as `azure_ad_token_provider`). API verified against the current `langchain-openai` release before committing — no stale SDK syntax.
- **Credential-free CI**: when Azure OpenAI is not configured, the graph falls back to a deterministic `GenericFakeChatModel`. The fake path never imports `langchain_openai`, so the smoke test needs no cloud creds or model SDK.
- Model SDKs (`langchain-openai`, `azure-identity`) stay **example-only** deps in the example's `requirements.txt` — never added to the base package.

## Acceptance checklist (issue #402)
- [x] Standalone deployable Azure Functions app.
- [x] Current supported Azure OpenAI + LangGraph integration, verified at implementation time.
- [x] Native invoke endpoint documented and exercised end-to-end with the fake model.
- [x] API-key local path documented.
- [x] Managed Identity / Entra ID production path documented (incl. required *Cognitive Services OpenAI User* role).
- [x] No Azure OpenAI / LangChain model dependency added to the base package.
- [x] CI smoke test uses a fake model, requires no cloud credentials.
- [x] Linked from `README.md` (after the 5-min tutorial) and `examples/README.md` (top).
- [x] `make lint` / `make typecheck` clean; full suite green at **96.27%** coverage (≥95% gate).

## Notes
- No release required: examples/docs only, depends only on existing public API. Pins `azure-functions-langgraph>=0.8,<0.9` (latest published: 0.8.1).
- Out of scope (follow-ups): conversation persistence (#403), tool calling (#404), true streaming.

Closes #402