### PR TITLE
ci: adopt azure/login v3.0.2 as the canonical pin

### DIFF
--- a/tools/lint_release_workflows.py
+++ b/tools/lint_release_workflows.py
@@ -42,7 +42,7 @@ CANONICAL_ACTIONS: dict[str, tuple[str, str]] = {
     # renovate: datasource=github-tags depName=actions/setup-python versioning=github-tags
     "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
     # renovate: datasource=github-tags depName=azure/login versioning=github-tags
-    "azure/login": ("f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", "v3.0.1"),
+    "azure/login": ("7ddb5af1ef8758cf1353cf3b42f940aee27ba21c", "v3.0.2"),
     # actions/upload-artifact + actions/download-artifact are deliberately held
     # as a v4 "canonical pair". Newer majors are NOT adopted automatically:
     # download-artifact v5+ raises the runner floor to Node 24 and flips


### PR DESCRIPTION
## Context
Dependabot (#401) bumped `azure/login` to **v3.0.2** (`7ddb5af1ef8758cf1353cf3b42f940aee27ba21c`) in `.github/workflows/e2e-azure.yml`, but the canonical pin table in `tools/lint_release_workflows.py` still declared **v3.0.1**. The mismatch makes `lint-workflows` report *"Release-workflow drift detected"*, which fails `make check-all` on `main` and therefore breaks every open PR's test jobs (e.g. #412).

## Change
- Update the canonical `azure/login` pin in `lint_release_workflows.py` from `v3.0.1` -> `v3.0.2`, matching the SHA dependabot already merged into the workflow.

## Verification
- `make lint-workflows` passes: pins and publish gate reported canonical, drift cleared.

## Out of scope
- No functional/library changes; docs-only examples PR #412 is unblocked once this lands on `main`.