### PR TITLE
docs(examples): add stateful conversation example with thread_id and checkpointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ pip install -e .[dev]
 
 > **Want a real agent, not an echo?** After the Quick Start, jump to the [**Azure OpenAI agent example**](examples/azure_openai_agent/) — a deployable LangGraph agent backed by a real Azure OpenAI deployment, with API-key and Managed Identity paths.
 
+> **Need it to remember the conversation?** Then continue to the [**conversation memory example**](examples/conversation_memory/) — the same agent plus a checkpointer, so the same `thread_id` keeps a conversation going across requests.
+
 ```python
 from langgraph.graph import END, START, StateGraph
 from typing_extensions import TypedDict

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@
 | --- | --- | --- |
 | Minimal | [`simple_agent`](simple_agent/) | Two-node greeting agent with sequential edges (deterministic, no LLM). |
 | **Real agent — start here** | [`azure_openai_agent`](azure_openai_agent/) ⭐ | **Recommended after Quick Start.** LangGraph agent backed by a real Azure OpenAI deployment; API-key and Managed Identity paths, deterministic fake-model fallback for CI. |
+| Stateful conversation | [`conversation_memory`](conversation_memory/) ⭐ | **The stateful delta after `azure_openai_agent`.** Same graph plus a checkpointer — same `thread_id` continues a conversation, a different `thread_id` is isolated. In-memory backend, fake-model fallback for CI. |
 | Platform SDK | [`platform_compat_sdk`](platform_compat_sdk/) ⭐ | `platform_compat=True` host driven by the official `langgraph-sdk` client. |
 | Persistent storage | [`persistent_agent_blob_table`](persistent_agent_blob_table/) | End-to-end Azure Blob checkpointer + Azure Table thread store, runnable on Azurite. |
 | DB checkpoint (local) | [`sqlite_checkpoint_local`](sqlite_checkpoint_local/) | LangGraph SQLite checkpointer wired via `create_sqlite_checkpointer()` for local dev. |
@@ -34,6 +35,7 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 
 - **Just want it running (no LLM)?** → `simple_agent`
 - **Want a real Azure OpenAI agent? (start here after Quick Start)** → `azure_openai_agent`
+- **Want conversation memory (same `thread_id` continues a chat)?** → `conversation_memory`
 - **Switching from LangGraph Cloud / using `langgraph-sdk`?** → `platform_compat_sdk`
 - **Need state to survive restarts and scale-out?** → `persistent_agent_blob_table`
 - **Deploying to Azure with Managed Identity (no secrets in App Settings)?** → `managed_identity_storage`

--- a/examples/conversation_memory/README.md
+++ b/examples/conversation_memory/README.md
@@ -1,0 +1,172 @@
+# Conversation Memory Example
+
+**Continue here after the [Azure OpenAI agent](../azure_openai_agent/).** That
+example is intentionally **stateless** — every request starts fresh. Real
+assistants need to remember the conversation, so this example adds exactly one
+thing: a **checkpointer**. Passing the same `thread_id` across HTTP requests now
+keeps the conversation going; a different `thread_id` is an independent
+conversation.
+
+The graph shape is otherwise identical to `azure_openai_agent` (a real Azure
+OpenAI chat agent with a deterministic fake-model fallback for
+credential-free CI). The **only** delta is:
+
+```python
+# graph.py — the stateful change is the checkpointer
+compiled_graph = builder.compile(checkpointer=InMemorySaver())
+```
+
+## Concepts (kept distinct on purpose)
+
+| Term | What it is | Used here? |
+| --- | --- | --- |
+| **`thread_id`** | LangGraph conversation identity, sent per request under `config.configurable.thread_id`. Same id → same conversation. | **Yes** — the core of this example. |
+| **Checkpointer** | Persists a thread's graph execution state between invokes. This example uses `InMemorySaver`. | **Yes** — this is the stateful delta. |
+| **Platform `ThreadStore`** | Metadata registry for the optional `platform_compat` layer. **Not** the same as conversation memory. | No — not required for native memory. |
+| **LangGraph `BaseStore`** | Long-term, cross-thread memory. | No — out of scope. |
+
+> **Thread metadata storage is *not* conversation memory.** The checkpointer is
+> what remembers the conversation. The Platform `ThreadStore` only tracks thread
+> metadata for the SDK-compatibility layer. See `PRD.md` / `COMPATIBILITY.md`.
+
+## Prerequisites
+
+- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) v4+
+- Python 3.10+
+- *(Optional)* an **Azure OpenAI** resource with a chat deployment. Without one,
+  the example runs against a deterministic fake model — perfect for trying the
+  memory behaviour locally with zero credentials.
+
+## Run locally
+
+```bash
+cd examples/conversation_memory
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+To use a real Azure OpenAI deployment, fill in the `AZURE_OPENAI_*` values in
+`local.settings.json` (same variables and auth paths as the
+[`azure_openai_agent`](../azure_openai_agent/#configuration) example).
+
+## Walk through one conversation
+
+The native invoke endpoint is the primary teaching path. The conversation
+identity lives under `config.configurable.thread_id`.
+
+**Request 1 — introduce yourself on thread `alice`:**
+
+```bash
+curl -s -X POST http://localhost:7071/api/graphs/conversation_agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "input": {"messages": [{"role": "human", "content": "My name is Alice."}]},
+        "config": {"configurable": {"thread_id": "alice"}}
+      }'
+```
+
+**Request 2 — ask on the *same* thread `alice`:**
+
+```bash
+curl -s -X POST http://localhost:7071/api/graphs/conversation_agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "input": {"messages": [{"role": "human", "content": "What is my name?"}]},
+        "config": {"configurable": {"thread_id": "alice"}}
+      }'
+```
+
+The second response's `messages` include the **earlier** turn (`"My name is
+Alice."`) because the checkpointer replayed thread `alice`'s state before
+running the graph. With a real Azure OpenAI deployment the assistant answers
+`"Alice"` from that history; with the fake model you still see the accumulated
+history that makes the answer possible.
+
+**Request 3 — a *different* thread `bob` is independent:**
+
+```bash
+curl -s -X POST http://localhost:7071/api/graphs/conversation_agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{
+        "input": {"messages": [{"role": "human", "content": "What is my name?"}]},
+        "config": {"configurable": {"thread_id": "bob"}}
+      }'
+```
+
+Thread `bob` has no prior turns, so it never sees Alice's messages — conversations
+are isolated per `thread_id`.
+
+## Inspect thread state
+
+The native state endpoint returns the persisted state for a thread:
+
+```bash
+curl -s http://localhost:7071/api/graphs/conversation_agent/threads/alice/state
+```
+
+```json
+{
+  "values": {
+    "messages": [
+      {"content": "My name is Alice.", "type": "human", "...": "..."},
+      {"content": "...", "type": "ai", "...": "..."},
+      {"content": "What is my name?", "type": "human", "...": "..."},
+      {"content": "...", "type": "ai", "...": "..."}
+    ]
+  },
+  "next": [],
+  "metadata": {"...": "..."}
+}
+```
+
+`values` is the checkpointed graph state; each `messages` item is a **serialized
+LangChain message** (`content`, `type`, `additional_kwargs`, ...), not a bare
+`{"role", "content"}` pair. Asking for a never-seen thread returns `404`.
+
+## What happens after a host restart?
+
+This example uses **`InMemorySaver`**, so thread state lives only in the running
+Functions **host process**. Restart `func start` (or let Azure recycle/scale the
+instance) and every thread's memory is gone — and because it is per-process, it
+is **not** shared across multiple Function App instances either.
+
+That trade keeps onboarding dependency-free while the concept is what matters.
+For restart-safe and scale-safe memory, keep the exact same graph and swap the
+checkpointer for a durable backend:
+
+- **Azure Blob + Table** → [`persistent_agent_blob_table`](../persistent_agent_blob_table/)
+- **Managed Identity (no secrets in App Settings)** → [`managed_identity_storage`](../managed_identity_storage/)
+- **SQLite (single-instance local/dev)** → [`sqlite_checkpoint_local`](../sqlite_checkpoint_local/)
+- **Postgres (multi-instance prod)** → [`postgres_checkpoint_production`](../postgres_checkpoint_production/)
+
+## Concurrency
+
+Native invoke/stream endpoints take an **in-process per-thread lock** when the
+graph has a checkpointer and the request carries a `thread_id`, so concurrent
+requests on the **same** thread within one worker are serialized. This lock is
+**in-process only** — multi-instance deployments must use a distributed
+`ThreadLock` backend or Platform-compatible runs with `AzureTableThreadStore`.
+See the main README's *Distributed thread locking* section.
+
+## Deploy to Azure
+
+Application code does not change between local and Azure. Follow the canonical
+[deployment guide](../../docs/deployment.md).
+
+> **Production auth:** `LangGraphApp` defaults to `AuthLevel.FUNCTION`, so the
+> deployed endpoints require a function key (`?code=<FUNCTION_KEY>` or the
+> `x-functions-key` header).
+
+> **Memory backend for production:** `InMemorySaver` is **not** production-safe
+> (state is lost on restart and never shared across instances). Switch to a
+> durable checkpointer — see the links above — before deploying anything that
+> must remember conversations.
+
+## CI / credential-free runs
+
+Unless Azure OpenAI is **fully** configured — endpoint, deployment, **and** an
+auth method (`AZURE_OPENAI_API_KEY`, or `AZURE_OPENAI_USE_ENTRA_ID=true`) —
+`graph.py` builds a deterministic `GenericFakeChatModel` instead of calling Azure
+OpenAI. This keeps the example importable and smoke-testable in CI without any
+cloud credentials, and the fake path never imports `langchain_openai`.

--- a/examples/conversation_memory/function_app.py
+++ b/examples/conversation_memory/function_app.py
@@ -1,0 +1,20 @@
+"""Conversation memory agent - Azure Functions entry point.
+
+Run from this directory:
+    func start
+"""
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+
+# Default auth_level is AuthLevel.FUNCTION — deployed endpoints require a
+# function key (`?code=<FUNCTION_KEY>` or the `x-functions-key` header).
+langgraph_app = LangGraphApp()
+langgraph_app.register(
+    graph=compiled_graph,
+    name="conversation_agent",
+    description="A stateful Azure cloud assistant that remembers a thread's prior turns via a checkpointer",
+)
+
+app = langgraph_app.function_app

--- a/examples/conversation_memory/graph.py
+++ b/examples/conversation_memory/graph.py
@@ -1,0 +1,158 @@
+"""Stateful conversation agent — checkpointer-backed LangGraph on Azure Functions.
+
+This is the **stateful delta** on top of the stateless
+[`azure_openai_agent`](../azure_openai_agent/) example. The graph shape is the
+same real-Azure-OpenAI chat agent (with a deterministic fake-model fallback for
+credential-free CI), with **one** change: the compiled graph is given a
+**checkpointer**, so passing the same ``thread_id`` across HTTP requests keeps
+the conversation going.
+
+Terminology (kept distinct on purpose):
+
+* **thread_id** — LangGraph execution/conversation identity, supplied per request
+  under ``config.configurable.thread_id``. Same id → same conversation.
+* **checkpointer** — persists a thread's graph execution state between invokes.
+  This example uses the in-memory ``InMemorySaver`` so onboarding needs zero
+  external services; state lives only for the life of the Functions **host
+  process** (see the README's restart note).
+* **Platform ``ThreadStore``** — metadata registry for the optional
+  ``platform_compat`` layer; **not** required for native conversation memory and
+  not used here.
+* **LangGraph ``BaseStore``** — long-term, cross-thread memory; **out of scope**.
+
+Native teaching path::
+
+    POST /api/graphs/conversation_agent/invoke        # same thread_id → continuity
+    GET  /api/graphs/conversation_agent/threads/{thread_id}/state
+
+Requirements::
+
+    pip install azure-functions-langgraph langgraph langchain-core langchain-openai azure-identity
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+from typing import Annotated, Any
+
+from typing_extensions import TypedDict
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+SYSTEM_PROMPT = (
+    "You are a concise Azure cloud assistant with memory of the current "
+    "conversation. Use the prior messages in this thread to stay consistent. "
+    "If you are unsure, say so rather than guessing."
+)
+
+# Azure OpenAI configuration (read at import / cold start).
+_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT")
+_DEPLOYMENT = os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY")
+_API_VERSION = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-10-21")
+_USE_ENTRA_ID = os.environ.get("AZURE_OPENAI_USE_ENTRA_ID", "").strip().lower() in _TRUTHY
+
+
+def _azure_configured() -> bool:
+    """True when enough config is present to build a real Azure OpenAI model."""
+    return bool(_ENDPOINT and _DEPLOYMENT and (_API_KEY or _USE_ENTRA_ID))
+
+
+def build_chat_model() -> Any:
+    """Construct the chat model for the agent.
+
+    Returns a real ``AzureChatOpenAI`` when Azure OpenAI is configured, else a
+    deterministic fake model for credential-free local runs and CI.
+    """
+    if _azure_configured():
+        # Import lazily so the fake path never requires langchain-openai.
+        from langchain_openai import AzureChatOpenAI
+
+        if _USE_ENTRA_ID and not _API_KEY:
+            from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+
+            token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(),
+                "https://cognitiveservices.azure.com/.default",
+            )
+            return AzureChatOpenAI(
+                azure_endpoint=_ENDPOINT,
+                azure_deployment=_DEPLOYMENT,
+                api_version=_API_VERSION,
+                azure_ad_token_provider=token_provider,
+            )
+
+        # API-key path.
+        return AzureChatOpenAI(
+            azure_endpoint=_ENDPOINT,
+            azure_deployment=_DEPLOYMENT,
+            api_version=_API_VERSION,
+            api_key=_API_KEY,
+        )
+
+    # Deterministic fallback — no cloud, no secrets, no langchain-openai.
+    #
+    # The fake echoes the latest human turn so the same-thread demo and CI tests
+    # can observe that history accumulated across invocations. A real model would
+    # instead *reason over* the thread history the checkpointer replays.
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.messages import AIMessage
+
+    def _replies() -> Any:
+        counter = itertools.count(1)
+        while True:
+            yield AIMessage(
+                content=(
+                    f"[fake model] turn {next(counter)} — Azure OpenAI is not configured. "
+                    "Set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT, and "
+                    "AZURE_OPENAI_API_KEY (or AZURE_OPENAI_USE_ENTRA_ID=true) to use a "
+                    "real deployment."
+                )
+            )
+
+    return GenericFakeChatModel(messages=_replies())
+
+
+try:
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.graph import END, START, StateGraph
+    from langgraph.graph.message import add_messages
+except ImportError as exc:  # pragma: no cover - defensive import guard
+    raise ImportError(
+        "langgraph and langchain-core are required for this example. Install with: "
+        "pip install azure-functions-langgraph langgraph langchain-core langchain-openai azure-identity"
+    ) from exc
+
+
+class AgentState(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+# Built once at cold start; reused across invocations. Azure/langchain-openai
+# import errors (if that path is configured) propagate with their own message.
+_model = build_chat_model()
+
+
+def chat(state: AgentState) -> dict[str, Any]:
+    """Single agent node: prepend the system prompt and call the model.
+
+    ``state["messages"]`` already includes every prior turn the checkpointer
+    replayed for this ``thread_id`` — that history is the conversation memory.
+    """
+    from langchain_core.messages import SystemMessage
+
+    response = _model.invoke([SystemMessage(content=SYSTEM_PROMPT), *state["messages"]])
+    return {"messages": [response]}
+
+
+builder = StateGraph(AgentState)
+builder.add_node("chat", chat)
+builder.add_edge(START, "chat")
+builder.add_edge("chat", END)
+
+# The checkpointer is the whole point of this example: it persists per-thread
+# state so repeated invokes with the same thread_id continue one conversation.
+# InMemorySaver keeps onboarding dependency-free; swap it for a durable backend
+# (see examples/persistent_agent_blob_table/) for restart/scale-safe storage.
+compiled_graph = builder.compile(checkpointer=InMemorySaver())

--- a/examples/conversation_memory/host.json
+++ b/examples/conversation_memory/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/conversation_memory/local.settings.json.example
+++ b/examples/conversation_memory/local.settings.json.example
@@ -1,0 +1,12 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AZURE_OPENAI_ENDPOINT": "",
+    "AZURE_OPENAI_DEPLOYMENT": "",
+    "AZURE_OPENAI_API_VERSION": "2024-10-21",
+    "AZURE_OPENAI_API_KEY": "",
+    "AZURE_OPENAI_USE_ENTRA_ID": ""
+  }
+}

--- a/examples/conversation_memory/requirements.txt
+++ b/examples/conversation_memory/requirements.txt
@@ -1,0 +1,14 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+#
+# langchain-openai + azure-identity are example-only dependencies. They are NOT
+# part of the base azure-functions-langgraph install — the package stays a
+# deployment adapter and does not pull in model SDKs. The checkpointer used here
+# (InMemorySaver) ships with langgraph, so no extra storage dependency is needed.
+
+azure-functions
+azure-functions-langgraph>=0.8,<0.9
+langgraph>=1.0,<2.0
+langchain-core>=1.0,<2.0
+langchain-openai>=0.3,<1.0
+azure-identity>=1.19,<2.0

--- a/tests/test_conversation_memory_example.py
+++ b/tests/test_conversation_memory_example.py
@@ -1,0 +1,85 @@
+"""Behavioural tests for the conversation_memory example.
+
+These assert the *stateful delta* the example teaches, using the deterministic
+fake-model fallback (no Azure OpenAI / Azure Storage credentials required):
+
+* same ``thread_id`` across invocations accumulates conversation history,
+* a different ``thread_id`` is isolated,
+* the persisted thread state has the shape the native state endpoint returns.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "examples" / "conversation_memory"
+
+
+def _load_graph_module() -> Any:
+    path = EXAMPLE_DIR / "graph.py"
+    spec = importlib.util.spec_from_file_location("_conversation_memory_graph", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.pop(0)
+    return mod
+
+
+@pytest.fixture()
+def compiled_graph() -> Any:
+    return _load_graph_module().compiled_graph
+
+
+def _human_contents(messages: list[Any]) -> list[str]:
+    return [m.content for m in messages if getattr(m, "type", None) == "human"]
+
+
+def test_same_thread_accumulates_history(compiled_graph: Any) -> None:
+    cfg = {"configurable": {"thread_id": "alice"}}
+
+    first = compiled_graph.invoke(
+        {"messages": [{"role": "human", "content": "My name is Alice."}]}, cfg
+    )
+    assert _human_contents(first["messages"]) == ["My name is Alice."]
+
+    second = compiled_graph.invoke(
+        {"messages": [{"role": "human", "content": "What is my name?"}]}, cfg
+    )
+    # The second invocation observes state written by the first: the earlier
+    # human turn is replayed by the checkpointer before the graph runs.
+    assert _human_contents(second["messages"]) == ["My name is Alice.", "What is my name?"]
+
+
+def test_different_thread_is_isolated(compiled_graph: Any) -> None:
+    compiled_graph.invoke(
+        {"messages": [{"role": "human", "content": "My name is Alice."}]},
+        {"configurable": {"thread_id": "alice"}},
+    )
+
+    bob = compiled_graph.invoke(
+        {"messages": [{"role": "human", "content": "What is my name?"}]},
+        {"configurable": {"thread_id": "bob"}},
+    )
+    # Bob never sees Alice's turns — conversations are isolated per thread_id.
+    assert _human_contents(bob["messages"]) == ["What is my name?"]
+
+
+def test_state_snapshot_shape(compiled_graph: Any) -> None:
+    cfg = {"configurable": {"thread_id": "carol"}}
+    compiled_graph.invoke({"messages": [{"role": "human", "content": "hello"}]}, cfg)
+
+    snapshot = compiled_graph.get_state(cfg)
+    # Mirrors handle_state(): values is the graph state dict with messages.
+    assert isinstance(snapshot.values, dict)
+    assert "messages" in snapshot.values
+    assert "hello" in _human_contents(snapshot.values["messages"])
+    assert list(snapshot.next) == []

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -11,6 +11,7 @@ EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples"
 GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("simple_agent", "compiled_graph"),
     ("azure_openai_agent", "compiled_graph"),
+    ("conversation_memory", "compiled_graph"),
     ("platform_compat_sdk", "compiled_graph"),
     ("openapi_bridge", "compiled_graph"),
     ("production_auth", "private_graph"),
@@ -59,6 +60,7 @@ REQUIRED_FILES = (
 EXAMPLE_DIRS = (
     "simple_agent",
     "azure_openai_agent",
+    "conversation_memory",
     "platform_compat_sdk",
     "persistent_agent_blob_table",
     "managed_identity_storage",


### PR DESCRIPTION
Closes #403

## Context
After `azure_openai_agent` (#402) proves a real agent runs on Azure Functions, the next question is *"how do I keep the conversation across requests?"* This adds the **stateful delta**: the same graph shape plus a checkpointer.

## Change
- New standalone `examples/conversation_memory/` (`graph.py`, `function_app.py`, `host.json`, `local.settings.json.example`, `requirements.txt`, `README.md`).
- Reuses the `azure_openai_agent` graph shape (real Azure OpenAI chat + deterministic fake-model fallback), with **one** change: `compiled_graph = builder.compile(checkpointer=InMemorySaver())`.
- README teaches the **native** invoke + state endpoints, walks the `alice → alice → bob` scenario (continuity + isolation), documents state inspection, explains the in-memory **restart caveat**, and links forward to the durable persistence examples.
- Terminology kept distinct: `thread_id` vs **checkpointer** vs Platform **ThreadStore** vs LangGraph **BaseStore**.
- Linked immediately after #402 in the main README and `examples/README.md`.

## Tests
- Registered in `tests/test_examples_smoke.py` (graph compiles + required files).
- New `tests/test_conversation_memory_example.py`: same-thread history accumulation, cross-thread isolation, and state-snapshot shape — all via the fake model, **no cloud credentials**.
- `make lint`, `make typecheck` clean; full suite green at **96.27%** coverage (≥95% gate).

## Acceptance checklist (#403)
- [x] Standalone + runnable with `func start`
- [x] Same-thread continuity demonstrated end to end
- [x] Cross-thread isolation demonstrated
- [x] State endpoint documented and smoke-tested
- [x] checkpointer vs ThreadStore vs BaseStore terminology distinct
- [x] CI uses a deterministic fake model, no cloud credentials
- [x] Linked after #402 in both READMEs
- [x] Links forward to the production persistent-storage example

## Out of scope
Cross-thread `BaseStore` memory, production multi-instance persistence, tool calling, durable async runs, true streaming.

## Release
Docs/example only — **no release required** (no change to the installable package).