### PR TITLE
docs: complete Phase 1 documentation gate (learning path + wheel-tests tier)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,8 @@ Release verification is layered; each tier is a **pre-publish gate**, not a post
 
 | Tier | Runs where | Catches |
 | --- | --- | --- |
-| `lib-tests` | publish-pypi.yml (per publish) | library unit regressions (against the built wheel) |
+| `lib-tests` | publish-pypi.yml (per publish) | library unit regressions against the **source tree** — this is where the ≥95% coverage gate is enforced |
+| `wheel-tests` | publish-pypi.yml (per publish) | packaging regressions — runs the **same unit suite (including the `examples/` smoke tests) against the *installed built wheel*** (imports resolve from site-packages, not `src/`), so missing wheel files, bad metadata, or install-only import errors fail fast. This is how the examples are exercised against a built wheel, not just the source tree. Coverage is not re-measured here. |
 | `verify-azure-certification` | publish-pypi.yml (per publish) | requires a fresh, SHA+version-matched **real-Azure** certification for the exact release commit |
 | Azure Release Certification (`e2e-azure.yml`) | `workflow_dispatch`, per release | cloud-only drift — deploys this package's own `examples/e2e_app/` to real Azure (Y1 Consumption), runs the native LangGraph HTTP e2e (health/invoke/stream), and records a certification artifact keyed by commit SHA + version. **Certified per release, not per publish.** |
 
@@ -99,7 +100,7 @@ Unlike the sibling repos, this package has **no** cookbook host-smoke tier. The 
 3. **Real-Azure certification (required once per release, before the final publish).** Before (or immediately after) pushing the release tag, dispatch the **Azure Release Certification** workflow on the exact release commit and version:
    - `gh workflow run e2e-azure.yml --ref main -f ref=<release-sha> -f version=<x.y.z>`
    - The run deploys `examples/e2e_app/` (with a wheel built from `<release-sha>`) to real Azure, executes the live e2e suite (health/invoke/stream), and uploads the `azure-cert` artifact (keyed by commit SHA + version).
-4. Tag push triggers the **Publish to PyPI** workflow. The `publish` job runs only after `build → lib-tests → verify-azure-certification` all pass, and it uploads the exact artifact that was built (it never rebuilds). `verify-azure-certification` requires a successful, SHA+version-matched, non-stale (<14 day) certification for the release commit; without it the publish gate fails and the version stays unpublished.
+4. Tag push triggers the **Publish to PyPI** workflow. The `publish` job runs only after `build → lib-tests → wheel-tests → verify-azure-certification` all pass, and it uploads the exact artifact that was built (it never rebuilds). `verify-azure-certification` requires a successful, SHA+version-matched, non-stale (<14 day) certification for the release commit; without it the publish gate fails and the version stays unpublished.
 5. Update `docs/changelog.md` separately if needed (different format from `CHANGELOG.md`).
 6. **Failed-gate recovery (stuck tag).** A git tag is immutable and may already have been consumed, so if the gate fails do **not** move or reuse the tag. Fix forward on `main` and cut the next patch tag (`make release-patch`). The unpublished version number is simply skipped.
 

--- a/README.md
+++ b/README.md
@@ -137,13 +137,18 @@ pip install -e .[dev]
 
 > **New to this package?** Follow the [**Deploy a LangGraph agent to Azure Functions in 5 minutes**](docs/tutorial-5-min.md) tutorial — a genuinely runnable, CI-smoke-tested walkthrough from a compiled graph to live HTTP endpoints, locally and on Azure.
 
-> **Want a real agent, not an echo?** After the Quick Start, jump to the [**Azure OpenAI agent example**](examples/azure_openai_agent/) — a deployable LangGraph agent backed by a real Azure OpenAI deployment, with API-key and Managed Identity paths.
+### Recommended learning path
 
-> **Need it to remember the conversation?** Then continue to the [**conversation memory example**](examples/conversation_memory/) — the same agent plus a checkpointer, so the same `thread_id` keeps a conversation going across requests.
+Once the Quick Start echo agent runs, follow these four examples in order. Each one is the **minimal delta** over the previous step, so you add exactly one production concern at a time — real LLM → memory → tools → durable persistence:
 
-> **Need the agent to call tools (APIs, DBs, other Functions)?** Continue to the [**tool-calling agent example**](examples/tool_calling_agent/) — the same agent plus a `ToolNode` loop, with the tools as your own code in `tools.py` and an OpenAPI/Swagger bridge wired in.
+| Step | Example | What it adds |
+| --- | --- | --- |
+| 1 | [**`azure_openai_agent`**](examples/azure_openai_agent/) | A real agent, not an echo — a deployable LangGraph agent backed by a real Azure OpenAI deployment, with API-key and Managed Identity paths. |
+| 2 | [**`conversation_memory`**](examples/conversation_memory/) | Memory — the same agent plus a checkpointer, so the same `thread_id` keeps a conversation going across requests. |
+| 3 | [**`tool_calling_agent`**](examples/tool_calling_agent/) | Tools — the same agent plus a `ToolNode` loop, with the tools as your own code in `tools.py` and an OpenAPI/Swagger bridge wired in. |
+| 4 | [**`production_persistent_agent`**](examples/production_persistent_agent/) | Durable production persistence — the same real agent whose per-`thread_id` memory is made durable on an Azure Blob checkpointer, wired with Managed Identity in production and Azurite locally. |
 
-> **Ready for production — memory that survives restarts and scale-out?** Finish the path with the [**production persistent agent example**](examples/production_persistent_agent/) — the same real Azure OpenAI agent whose per-`thread_id` memory is made durable on an Azure Blob checkpointer, wired with Managed Identity in production and Azurite locally. This is the four-step adoption path (real agent → memory → tools → durable production persistence) end to end.
+This `azure_openai_agent → conversation_memory → tool_calling_agent → production_persistent_agent` progression takes you from a real agent to a durable, production-ready one end to end. Every example is a standalone Azure Functions app with a deterministic fake-model fallback, so all four pass CI without any cloud credentials.
 
 ```python
 from langgraph.graph import END, START, StateGraph


### PR DESCRIPTION
## Summary
Completes the outstanding **Phase 1 documentation gate** from the roadmap (#410) now that all four Phase 1 examples (#402→#403→#404→#405) are merged.

- **Main README** — adds a visible `### Recommended learning path` **section** (a real heading, not scattered inline callouts) presenting the four-step adoption path as a scannable table: `azure_openai_agent` (real agent) → `conversation_memory` (memory) → `tool_calling_agent` (tools) → `production_persistent_agent` (durable persistence). Satisfies the gate's "Main README has a visible Recommended learning path" item.
- **AGENTS.md** — corrects the tiered runtime table: `lib-tests` runs against the **source tree** (where the ≥95% coverage gate lives), and a new **`wheel-tests`** row documents that the examples' smoke suite is exercised against the **installed built wheel**. This is the pipeline that satisfies the gate's "examples import/test against a built wheel where practical" item, and the table previously omitted it.

## Phase 1 gate status (evidence)
- ✅ Visible Recommended learning path section — **this PR**
- ✅ Every example standalone Functions app + smoke coverage — `examples/README.md` Conventions
- ✅ Examples tested against a built wheel — `publish-pypi.yml` `wheel-tests` job (now documented)
- ✅ No example needs cloud credentials in CI — deterministic fake-model fallbacks
- ✅ #402 and #405 documented real-Azure verification path — `azure_openai_agent` "Deploy to Azure" + `production_persistent_agent` "Deploy to Azure with Managed Identity"

## Verification
- `make lint` ✅
- `make typecheck` ✅ (73 files)
- Example/docs tests pass (Azurite-backed tests skip locally, as expected)
- Docs-only change — no runtime code touched, coverage unaffected

Refs #410 (does not close the umbrella tracker).