### PR TITLE
ci(examples): run production_persistent_agent durability test under Azurite

### DIFF
--- a/.github/workflows/ci-table-integration.yml
+++ b/.github/workflows/ci-table-integration.yml
@@ -44,3 +44,12 @@ jobs:
 
       - name: Run blob checkpointer conformance (Azurite)
         run: pytest -v -m integration tests/integration/test_checkpoint_conformance.py --no-cov
+
+      - name: Run production_persistent_agent capstone durability test (Azurite)
+        # The learning-path capstone's durability promise (state survives
+        # checkpointer recreation) is proven only here: this is the one job that
+        # provides a live Azurite blob backend for
+        # tests/test_production_persistent_agent_example.py. Without it the test
+        # skips in every other job, leaving the capstone's core claim unverified
+        # in CI (issue #418).
+        run: pytest -v -m integration tests/test_production_persistent_agent_example.py --no-cov


### PR DESCRIPTION
## Summary
- Closes #418. The learning-path capstone (`production_persistent_agent`) claims **durable persistence** — state written via `AzureBlobCheckpointSaver` survives recreation of the checkpointer. That claim was asserted only by `tests/test_production_persistent_agent_example.py`, which `pytest.skip()`s when Azurite is unreachable.
- **No CI job started Azurite for that file**, so the assertion was skipped in every job (`ci-test.yml`, af-2.x compat, wheel-tests) — the capstone's core promise was effectively unverified in CI (fast-rotting).
- This adds the test to the `table-integration` job, which already spins up a live Azurite blob backend on port 10000 and installs `[dev,azure-table,azure-blob]` — the exact dependencies the test needs. One-line, isolated change; no new services.

## Verification
Reproduced locally against a **wheel-installed build on Python 3.13** with a fresh Azurite (Docker `mcr.microsoft.com/azure-storage/azurite:latest`, matching CI):

```
tests/test_production_persistent_agent_example.py ..   [100%]
2 passed in 2.68s
```

Without Azurite the test still skips cleanly, so contributors without a local emulator are unaffected.

## Out of scope
- Real-Azure certification of the capstone (`e2e-azure.yml`, blocked on #333 OIDC).
- Adding Azurite to wheel-tests / af-2.x jobs — compile-level smoke there is sufficient; durability only needs to run in one job.