### PR TITLE
ci(langgraph): certify LangGraph 1.2.x / langgraph-sdk 0.4.x and adopt a rolling minimum-version window

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -113,6 +113,41 @@ jobs:
         # this pinned run (a separate job from the coverage-enforcing matrix).
         run: pytest tests/test_sdk_contracts.py tests/test_sdk_compat.py --no-cov -q
 
+  langgraph-latest:
+    name: langgraph compat (latest certified 1.2.x)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install package and dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,azure-blob,azure-table]"
+
+      - name: Pin langgraph to the latest certified 1.2.x + langgraph-sdk 0.4.x
+        # Rolling-window certification (issue #421): langgraph core 1.2.9+ pins
+        # langgraph-sdk >=0.4.2,<0.5, a line the default dev resolve now already
+        # picks up. This lane pins the floor of that window explicitly so the
+        # latest supported LangGraph/SDK pair is proven even if a future core
+        # release temporarily regresses the default resolve. The langgraph-min
+        # lane pins langgraph==1.0.0 to hold the other end of the window.
+        run: pip install "langgraph>=1.2.9,<2" "langgraph-sdk>=0.4.2,<0.5"
+
+      - name: Show resolved versions
+        run: pip show langgraph langgraph-sdk | grep -E '^(Name|Version):'
+
+      - name: Run tests against the latest certified langgraph line
+        # Compatibility smoke only: `--no-cov` disables the coverage gate for this
+        # pinned run (a separate job from the coverage-enforcing matrix).
+        run: pytest tests/ --no-cov -q
+
+
   azure-functions-2x:
     name: azure-functions 2.x compat (Py 3.13)
     runs-on: ubuntu-latest

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,14 +4,32 @@
 
 | Package | Supported Versions | Notes |
 |---|---|---|
-| `langgraph` | `>=1.0,<2.0` | Runtime dependency. CI covers the minimum supported 1.x release (1.0.0) plus the latest resolved 1.x release on every Python version (3.10–3.14). |
-| `langgraph-sdk` | `>=0.2.2,<0.4` | Platform compat layer mirrors this SDK version's REST API shapes. The floor tracks the minimum supported `langgraph` (1.0.0), which resolves `langgraph-sdk 0.2.2`. |
+| `langgraph` | `>=1.0,<2.0` | Runtime dependency. CI certifies both ends of the supported window on a rolling basis: the `langgraph-min` lane pins the minimum supported 1.x release (1.0.0), and the `langgraph-latest` lane pins the latest certified 1.2.x. The coverage-gated matrix (Python 3.10–3.14) resolves the newest compatible 1.x by default. |
+| `langgraph-sdk` | `>=0.2.2,<0.5` | Platform compat layer mirrors this SDK version's REST API shapes. The floor tracks the minimum supported `langgraph` (1.0.0 -> `langgraph-sdk 0.2.2`); the ceiling was lifted to `<0.5` once `langgraph` core 1.2.9+ moved to `langgraph-sdk >=0.4.2,<0.5`. The 0.4.x wire surface is certified identical to 0.3.x (issue #368 spike + `langgraph-latest` lane, #421). |
 | `pydantic` | `>=2.0` | Required for request/response models. |
 | `azure-functions` | `>=1.17` | Azure Functions Python v2 programming model. |
 
+### Rolling minimum-version window
+
+This package tracks a **rolling window** of supported LangGraph releases rather
+than freezing a single pinned version. The window has two ends, both enforced in
+CI (`.github/workflows/ci-test.yml`):
+
+- **Minimum** — the lowest LangGraph release the package promises to run on. The
+  `langgraph-min` lane pins `langgraph==1.0.0` (which resolves `langgraph-sdk
+  0.2.2`) and runs the suite against it.
+- **Latest certified** — the newest LangGraph line proven compatible. The
+  `langgraph-latest` lane pins `langgraph>=1.2.9,<2` + `langgraph-sdk>=0.4.2,<0.5`.
+
+As the ecosystem moves, the minimum is advanced deliberately (tied to this
+package's own version milestones) and the latest-certified lane is bumped to the
+newest proven LangGraph line. The default, coverage-gated test matrix resolves
+the newest compatible release automatically, so a regression in the latest line
+is caught by the gate, not silently shipped.
+
 ## Platform Compatibility Layer
 
-The `platform/` subpackage mirrors the LangGraph Platform REST API as understood by `langgraph-sdk >=0.2.2,<0.4`. This means:
+The `platform/` subpackage mirrors the LangGraph Platform REST API as understood by `langgraph-sdk >=0.2.2,<0.5`. This means:
 
 1. **Response shapes** — JSON response structures match what `langgraph-sdk` expects. Required fields, types, and nesting are tested via contract tests in `tests/test_sdk_contracts.py`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,13 @@ dev = [
     "ruff==0.16.5",
     "requests",
     "types-requests",
-    # Ceiling <0.4 is NOT ours to lift independently: langgraph core (a runtime
-    # dep, langgraph>=1.0,<2.0 -> currently 1.1.x) itself pins langgraph-sdk
-    # <0.4.0,>=0.3.0, so the resolver keeps the SDK <0.4 regardless. The 0.4.3
-    # wire surface is in fact compatible (see the #368 spike in
-    # tests/test_sdk_contracts.py), but the cap stays until langgraph core relaxes.
-    "langgraph-sdk>=0.2.2,<0.4",
+    # langgraph core 1.2.9+ pins langgraph-sdk >=0.4.2,<0.5, so the resolver now
+    # pulls the 0.4.x line by default. The 0.4.x wire surface this package mirrors
+    # is compatible (verified by the #368 spike in tests/test_sdk_contracts.py and
+    # the full suite green under langgraph 1.2.11 + langgraph-sdk 0.4.4 in the
+    # `langgraph-latest` CI lane, #421). The floor stays at 0.2.2 so the
+    # `langgraph-min` lane (langgraph==1.0.0 -> langgraph-sdk 0.2.2) still resolves.
+    "langgraph-sdk>=0.2.2,<0.5",
     "langgraph-checkpoint-conformance>=0.0.2,<0.1",
 ]
 docs = [

--- a/tests/test_sdk_contracts.py
+++ b/tests/test_sdk_contracts.py
@@ -157,10 +157,10 @@ def _parse_version(raw: str) -> tuple[int, int]:
 
 
 def test_installed_langgraph_sdk_within_supported_range() -> None:
-    """Drift guard: the installed langgraph-sdk must stay within >=0.2.2,<0.4.
+    """Drift guard: the installed langgraph-sdk must stay within >=0.2.2,<0.5.
 
     The ``platform/contracts.py`` response/request models mirror the
-    ``langgraph-sdk >=0.2.2,<0.4`` wire format. This single source of truth is
+    ``langgraph-sdk >=0.2.2,<0.5`` wire format. This single source of truth is
     also pinned in ``pyproject.toml`` (dev extra) and documented in
     ``COMPATIBILITY.md``. If the installed SDK falls outside the range, the
     contract models may silently drift from the real wire format, so fail
@@ -170,13 +170,15 @@ def test_installed_langgraph_sdk_within_supported_range() -> None:
     surface this package mirrors (Assistant, Thread, ThreadState, ThreadTask,
     Run, RunCreate, Checkpoint) is byte-identical to 0.3.x, sse.py/errors.py
     differ only in type-checker-ignore comment style, and 0.4.3 keeps
-    ``Requires-Python >=3.10``. The ``<0.4`` ceiling is therefore NOT a wire
-    limitation — it is transitively enforced by langgraph core (``langgraph``
-    1.1.x pins ``langgraph-sdk<0.4.0,>=0.3.0``). Lifting this package's own cap
-    to ``<0.5`` would be inert (the resolver keeps <0.4 via langgraph core) and
-    harmful if force-installed, so the cap stays put until langgraph core
-    relaxes its own bound.
+    ``Requires-Python >=3.10``.
+
+    Issue #421: langgraph core 1.2.9+ pins ``langgraph-sdk>=0.4.2,<0.5``, so the
+    resolver now pulls the 0.4.x line by default. The full suite is certified
+    against langgraph 1.2.x + langgraph-sdk 0.4.x (see the ``langgraph-latest``
+    CI lane), so this package's dev cap was lifted from ``<0.4`` to ``<0.5`` and
+    the ceiling below tracks that. The ``langgraph-min`` lane still pins
+    langgraph==1.0.0 (which resolves langgraph-sdk 0.2.2) to hold the floor.
     """
     major, minor = _parse_version(importlib_metadata.version("langgraph-sdk"))
     assert (major, minor) >= (0, 2), "langgraph-sdk below supported floor >=0.2.2"
-    assert (major, minor) < (0, 4), "langgraph-sdk at/above unsupported ceiling <0.4"
+    assert (major, minor) < (0, 5), "langgraph-sdk at/above unsupported ceiling <0.5"


### PR DESCRIPTION
## Summary

Closes #421.

`langgraph` core 1.2.9+ moved its `langgraph-sdk` pin to `>=0.4.2,<0.5`, but this package's dev cap of `langgraph-sdk<0.4` held the resolver at `langgraph` 1.1.x — so the **latest** LangGraph line was never actually exercised in CI. This PR certifies the latest 1.2.x / 0.4.x pair and formalises a **rolling minimum-version window** instead of chasing a single frozen pin.

## Changes

- **`pyproject.toml`** — lift the dev `langgraph-sdk` cap from `<0.4` to `<0.5` (floor stays `0.2.2`). The default, coverage-gated matrix now resolves `langgraph 1.2.11 + langgraph-sdk 0.4.4`. Stale rationale comment rewritten.
- **`.github/workflows/ci-test.yml`** — add a `langgraph-latest` lane pinning `langgraph>=1.2.9,<2` + `langgraph-sdk>=0.4.2,<0.5`. Together with the existing `langgraph-min` lane (pins `langgraph==1.0.0`), both ends of the supported window are certified.
- **`tests/test_sdk_contracts.py`** — drift-guard ceiling `<0.4` → `<0.5`; docstring updated to reflect the 0.4.x certification.
- **`COMPATIBILITY.md`** — corrected the misleading "latest resolved 1.x" wording, bumped the `langgraph-sdk` row to `<0.5`, and added an explicit **Rolling minimum-version window** policy section.

## Verification

Full suite run against the target latest pair (`langgraph 1.2.11` + `langgraph-sdk 0.4.4`):

- `make lint` ✅
- `make typecheck` ✅ (73 files)
- `make test` ✅ — **1058 passed, coverage 96.27%** (gate ≥95%)

The 0.4.x wire surface is byte-identical to 0.3.x for the mirrored Platform contract models (issue #368 spike), so no `platform/` code changes were required.

## Notes

- No runtime dependency floor change: at the current package version (0.8.2) the rolling-window minimum stays `langgraph>=1.0`; the floor advances to `>=1.1` at 0.9 per the agreed rolling rule.
- No manual version bump (handled by `make release-*`).