### PR TITLE
feat(native): forward optional version to invoke/stream (#423)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@
 | Managed Identity | [`managed_identity_storage`](managed_identity_storage/) | Same backends wired with `DefaultAzureCredential` for production, with Azurite fallback for local dev. |
 | OpenAPI bridge (isolated) | [`openapi_bridge`](openapi_bridge/) | Minimal echo graph showing `register_with_openapi` wiring in isolation. For the bridge on a **real agent**, see `tool_calling_agent`. |
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |
+| Versioned output | [`versioned_output_agent`](versioned_output_agent/) | Opt into LangGraph's `version="v2"` unified `GraphOutput` / `StreamPart` shapes via the request contract. |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
 | Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
 

--- a/examples/versioned_output_agent/README.md
+++ b/examples/versioned_output_agent/README.md
@@ -1,0 +1,103 @@
+# Versioned Output Agent Example
+
+Demonstrates the optional **`version` pass-through** on the native
+`invoke`/`stream` endpoints (issue #423). A trivial two-node counter graph
+(`increment` → `double`) keeps the focus on the request contract rather than the
+graph logic.
+
+`version` is **opt-in per request** and fully backward-compatible — omit it and
+you get the current behavior; set it to `"v2"` to receive LangGraph 1.1+'s
+unified output shapes.
+
+## Prerequisites
+
+- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) v4+
+- Python 3.10+
+- `langgraph>=1.1` (required for `version="v2"`)
+
+## Run locally
+
+```bash
+cd examples/versioned_output_agent
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+## Test
+
+### Default (no `version`) — legacy output
+
+`invoke` returns the graph's final **state dict** under `output`:
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/versioned_output_agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"count": 1, "history": []}}'
+```
+
+```json
+{"output": {"count": 4, "history": [2, 4]}}
+```
+
+### `version: "v2"` — unified `GraphOutput` shape
+
+With `"version": "v2"`, `invoke` returns LangGraph's `GraphOutput`, serialized as
+`{"value": <state>, "interrupts": [...]}`:
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/versioned_output_agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"count": 1, "history": []}, "version": "v2"}'
+```
+
+```json
+{"output": {"value": {"count": 4, "history": [2, 4]}, "interrupts": []}}
+```
+
+### Streaming with `version: "v2"` — unified `StreamPart` events
+
+Without `version`, `stream` emits `stream_mode`-shaped events. With `"version":
+"v2"`, each SSE `data` event is a unified `StreamPart`
+`{"type", "ns", "data", "interrupts"}`:
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/versioned_output_agent/stream \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"count": 1, "history": []}, "stream_mode": "values", "version": "v2"}'
+```
+
+```
+event: data
+data: {"type": "values", "ns": [], "data": {"count": 1, "history": []}, "interrupts": []}
+
+event: data
+data: {"type": "values", "ns": [], "data": {"count": 2, "history": [2]}, "interrupts": []}
+
+event: data
+data: {"type": "values", "ns": [], "data": {"count": 4, "history": [2, 4]}, "interrupts": []}
+
+event: end
+data: {}
+```
+
+> **Streaming is buffered SSE.** As with every `/stream` endpoint in this
+> package, chunks are collected during execution and flushed after the run
+> completes — `version="v2"` changes the **event shape**, not the buffering
+> behavior.
+
+### Unsupported `version`
+
+Passing a `version` to a graph whose `invoke`/`stream` does not accept one (e.g.
+`langgraph<1.1` or a custom structural graph) returns a clear `422` rather than
+an opaque server error:
+
+```json
+{"error": "error", "detail": "Graph 'versioned_output_agent' does not accept a 'version' argument (requires langgraph>=1.1)"}
+```
+
+### Health check
+
+```bash
+curl http://localhost:7071/api/health
+```

--- a/examples/versioned_output_agent/function_app.py
+++ b/examples/versioned_output_agent/function_app.py
@@ -1,0 +1,18 @@
+"""Versioned-output agent - Azure Functions entry point.
+
+Run from this directory:
+    func start
+"""
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+
+langgraph_app = LangGraphApp()
+langgraph_app.register(
+    graph=compiled_graph,
+    name="versioned_output_agent",
+    description="A counter agent demonstrating the optional version='v2' pass-through",
+)
+
+app = langgraph_app.function_app

--- a/examples/versioned_output_agent/graph.py
+++ b/examples/versioned_output_agent/graph.py
@@ -1,0 +1,83 @@
+"""Versioned-output example: opt into LangGraph's ``version="v2"`` shapes.
+
+This example shows the **request-level ``version`` pass-through** (issue #423).
+The graph itself is deliberately trivial — a two-step counter — so the focus is
+on how the native ``invoke``/``stream`` endpoints forward an optional
+``version`` field through to ``graph.invoke(..., version=...)`` /
+``graph.stream(..., version=...)``.
+
+* ``version`` omitted (default) → legacy LangGraph output (a bare state dict for
+  ``invoke``; ``stream_mode``-shaped events for ``stream``).
+* ``version="v2"`` → the unified LangGraph 1.1+ shapes: ``invoke`` returns a
+  ``GraphOutput`` serialized as ``{"value": ..., "interrupts": [...]}`` and
+  ``stream`` emits ``StreamPart`` events ``{"type", "ns", "data", "interrupts"}``.
+
+Requires ``langgraph>=1.1`` for ``version="v2"``; the default path works on any
+supported LangGraph version.
+
+Requirements::
+
+    pip install azure-functions-langgraph "langgraph>=1.1"
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+# ------------------------------------------------------------------
+# 1. Define state
+# ------------------------------------------------------------------
+
+
+class CounterState(TypedDict):
+    count: int
+    history: list[int]
+
+
+# ------------------------------------------------------------------
+# 2. Define node functions
+# ------------------------------------------------------------------
+
+
+def increment(state: CounterState) -> dict[str, Any]:
+    """First node — bump the counter by one."""
+    new_count = state["count"] + 1
+    return {"count": new_count, "history": [*state.get("history", []), new_count]}
+
+
+def double(state: CounterState) -> dict[str, Any]:
+    """Second node — double the counter."""
+    new_count = state["count"] * 2
+    return {"count": new_count, "history": [*state.get("history", []), new_count]}
+
+
+# ------------------------------------------------------------------
+# 3. Build the graph (using LangGraph API)
+# ------------------------------------------------------------------
+
+# NOTE: This block is guarded so the module can be imported without langgraph
+# installed (e.g. for testing the example structure).
+try:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(CounterState)
+    builder.add_node("increment", increment)
+    builder.add_node("double", double)
+    builder.add_edge(START, "increment")
+    builder.add_edge("increment", "double")
+    builder.add_edge("double", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError:
+    raise ImportError(
+        "langgraph is required for this example. "
+        "Install it with: pip install 'langgraph>=1.1' langchain-core"
+    )

--- a/examples/versioned_output_agent/host.json
+++ b/examples/versioned_output_agent/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/versioned_output_agent/local.settings.json.example
+++ b/examples/versioned_output_agent/local.settings.json.example
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}

--- a/examples/versioned_output_agent/requirements.txt
+++ b/examples/versioned_output_agent/requirements.txt
@@ -1,0 +1,8 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph==0.1.0a0
+# version="v2" pass-through requires langgraph>=1.1
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -9,6 +9,7 @@ receives only the explicit dependencies it needs — no reference to
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import json
 import logging
 from typing import Any, Protocol, TypeVar
@@ -67,6 +68,45 @@ def _error_response(status_code: int, detail: str) -> func.HttpResponse:
         status_code=status_code,
     )
 
+
+def _method_accepts_version(method: Any) -> bool:
+    """Return ``True`` if *method* accepts a ``version`` keyword argument.
+
+    Used to decide whether a caller-supplied ``version`` can be forwarded to a
+    structural graph. Matches an explicit ``version`` parameter or a
+    ``**kwargs`` catch-all; returns ``False`` when the signature cannot be
+    introspected (e.g. some C-level callables).
+    """
+    try:
+        sig = inspect.signature(method)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.name == "version" or param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
+
+
+def _resolve_version_kwarg(
+    method: Any, version: str | None, graph_name: str
+) -> dict[str, str] | func.HttpResponse:
+    """Resolve the caller's ``version`` request into forwardable kwargs.
+
+    Returns ``{}`` when no version was requested, ``{"version": version}`` when
+    it can be forwarded, or a ``422`` error response when the caller asked for a
+    version but the target graph method does not accept one. Capability is
+    detected structurally so any ``LangGraphLike`` graph works without requiring
+    ``version`` on the base protocol.
+    """
+    if version is None:
+        return {}
+    if not _method_accepts_version(method):
+        return _error_response(
+            422,
+            f"Graph {graph_name!r} does not accept a 'version' argument "
+            "(requires langgraph>=1.1)",
+        )
+    return {"version": version}
 
 class _ParsableRequest(Protocol):
     """Structural type for the native invoke/stream request bodies."""
@@ -194,6 +234,9 @@ def handle_invoke(
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
         return _error_response(400, cfg_err)
+    version_kwargs = _resolve_version_kwarg(reg.graph.invoke, request.version, reg.name)
+    if isinstance(version_kwargs, func.HttpResponse):
+        return version_kwargs
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
@@ -203,7 +246,7 @@ def handle_invoke(
                 409, f"Thread {thread_id!r} is currently in use by another request"
             )
     try:
-        result = reg.graph.invoke(request.input, config=config)
+        result = reg.graph.invoke(request.input, config=config, **version_kwargs)
     except Exception as exc:
         logger.exception("Graph %s invoke failed", reg.name)
         _ = exc
@@ -266,6 +309,9 @@ def handle_stream(
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
         return _error_response(400, cfg_err)
+    version_kwargs = _resolve_version_kwarg(reg.graph.stream, request.version, reg.name)
+    if isinstance(version_kwargs, func.HttpResponse):
+        return version_kwargs
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
@@ -301,6 +347,7 @@ def handle_stream(
             request.input,
             config=config,
             stream_mode=request.stream_mode,
+            **version_kwargs,
         ):
             serialized = json.dumps(
                 event if isinstance(event, dict) else {"data": str(event)},

--- a/src/azure_functions_langgraph/contracts.py
+++ b/src/azure_functions_langgraph/contracts.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Mapping, Optional, TypeGuard
+from typing import Any, Literal, Mapping, Optional, TypeGuard
 
 from pydantic import BaseModel, Field, create_model
 
+# LangGraph's ``invoke``/``stream`` (and their async twins) accept an optional
+# ``version`` argument since LangGraph 1.1: ``"v2"`` returns the unified
+# ``GraphOutput`` / ``StreamPart`` shapes, while ``"v1"`` preserves the legacy
+# output. We expose this as an opt-in request field — the default (``None``)
+# omits the argument entirely, so existing clients see no behaviour change.
+LangGraphVersion = Literal["v1", "v2"]
 
 class InvokeRequest(BaseModel):
     """Request body for graph invocation."""
@@ -16,6 +22,14 @@ class InvokeRequest(BaseModel):
     config: Optional[dict[str, Any]] = Field(
         default=None,
         description="LangGraph config, e.g. {'configurable': {'thread_id': '...'}}",
+    )
+    version: Optional[LangGraphVersion] = Field(
+        default=None,
+        description=(
+            "Optional LangGraph output version ('v1' or 'v2'). Forwarded to "
+            "graph.invoke(..., version=...) only when set; requires langgraph>=1.1. "
+            "'v2' returns a GraphOutput {'value', 'interrupts'} shape."
+        ),
     )
 
 
@@ -30,6 +44,14 @@ class StreamRequest(BaseModel):
     stream_mode: str = Field(
         default="values",
         description="Stream mode: 'values', 'updates', 'messages', or 'custom'",
+    )
+    version: Optional[LangGraphVersion] = Field(
+        default=None,
+        description=(
+            "Optional LangGraph output version ('v1' or 'v2'). Forwarded to "
+            "graph.stream(..., version=...) only when set; requires langgraph>=1.1. "
+            "'v2' emits unified StreamPart {'type','ns','data','interrupts'} events."
+        ),
     )
 
 
@@ -78,6 +100,16 @@ def build_invoke_request_model(input_model: Optional[type[Any]]) -> type[BaseMod
                     description="LangGraph config, e.g. {'configurable': {'thread_id': '...'}}",
                 ),
             ),
+            version=(
+                Optional[LangGraphVersion],
+                Field(
+                    default=None,
+                    description=(
+                        "Optional LangGraph output version ('v1' or 'v2'); "
+                        "forwarded to graph.invoke only when set (requires langgraph>=1.1)."
+                    ),
+                ),
+            ),
         )
     return InvokeRequest
 
@@ -121,6 +153,16 @@ def build_stream_request_model(input_model: Optional[type[Any]]) -> type[BaseMod
                 Field(
                     default="values",
                     description="Stream mode: 'values', 'updates', 'messages', or 'custom'",
+                ),
+            ),
+            version=(
+                Optional[LangGraphVersion],
+                Field(
+                    default=None,
+                    description=(
+                        "Optional LangGraph output version ('v1' or 'v2'); "
+                        "forwarded to graph.stream only when set (requires langgraph>=1.1)."
+                    ),
                 ),
             ),
         )

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -20,6 +20,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("managed_identity_storage", "compiled_graph"),
     ("cosmos_checkpoint_azure", "compiled_graph"),
     ("production_persistent_agent", "compiled_graph"),
+    ("versioned_output_agent", "compiled_graph"),
 )
 
 
@@ -71,6 +72,7 @@ EXAMPLE_DIRS = (
     "production_auth",
     "cosmos_checkpoint_azure",
     "production_persistent_agent",
+    "versioned_output_agent",
 )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -452,3 +452,164 @@ class TestNativeStreamState:
         assert state_data["values"]["history"] == ["Hello, Streamer!"]
         assert state_data["values"]["last_reply"] == "Hello, Streamer!"
         assert state_data["next"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — version pass-through (#423)
+# ---------------------------------------------------------------------------
+
+
+class TestNativeVersionPassthrough:
+    """Forwarding the optional ``version`` field to invoke/stream (#423)."""
+
+    def test_invoke_v2_returns_graph_output_envelope(self) -> None:
+        """version='v2' invoke returns the GraphOutput {value, interrupts} shape."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Alice", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "v2-t1"}},
+                "version": "v2",
+            },
+        )
+        resp = handler(req)
+        assert resp.status_code == 200
+        output = json.loads(resp.get_body())["output"]
+
+        # v2 wraps the state in a GraphOutput envelope, unlike the default shape.
+        assert set(output.keys()) == {"value", "interrupts"}
+        assert output["value"]["last_reply"] == "Hello, Alice!"
+        assert output["value"]["turn_count"] == 1
+        assert output["interrupts"] == []
+
+    def test_invoke_default_shape_unchanged(self) -> None:
+        """Omitting version keeps the flat state dict (no behavior change)."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Alice", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "v-default"}},
+            },
+        )
+        resp = handler(req)
+        assert resp.status_code == 200
+        output = json.loads(resp.get_body())["output"]
+
+        # Flat state — no GraphOutput envelope.
+        assert "value" not in output
+        assert output["last_reply"] == "Hello, Alice!"
+        assert output["turn_count"] == 1
+
+    def test_stream_v2_emits_streampart_frames(self) -> None:
+        """version='v2' stream yields StreamPart dicts (type/ns/data/interrupts)."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {
+                "input": {"user_text": "Bob", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "v2-stream"}},
+                "stream_mode": "values",
+                "version": "v2",
+            },
+        )
+        resp = handler(req)
+        assert resp.status_code == 200
+        frames = _parse_sse_frames(resp.get_body().decode())
+        data_frames = [
+            f for f in frames if f["event"] == "data" and isinstance(f["data"], dict)
+        ]
+        assert data_frames
+        for frame in data_frames:
+            # StreamPart shape rather than a bare state snapshot.
+            assert set(frame["data"].keys()) == {"type", "ns", "data", "interrupts"}
+            assert frame["data"]["type"] == "values"
+        final = data_frames[-1]["data"]["data"]
+        assert final["turn_count"] == 1
+        assert final["last_reply"] == "Hello, Bob!"
+
+    def test_invoke_invalid_version_rejected(self) -> None:
+        """An out-of-range version value fails Literal validation with 422."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Alice"},
+                "version": "v9",
+            },
+        )
+        resp = handler(req)
+        assert resp.status_code == 422
+
+
+class TestVersionKwargHelpers:
+    """Unit coverage for the structural version-capability helpers (#423)."""
+
+    def test_method_accepts_explicit_version_param(self) -> None:
+        from azure_functions_langgraph._handlers import _method_accepts_version
+
+        def fn(input: Any, *, version: str | None = None) -> None: ...
+
+        assert _method_accepts_version(fn) is True
+
+    def test_method_accepts_var_keyword(self) -> None:
+        from azure_functions_langgraph._handlers import _method_accepts_version
+
+        def fn(input: Any, **kwargs: Any) -> None: ...
+
+        assert _method_accepts_version(fn) is True
+
+    def test_method_without_version_rejected(self) -> None:
+        from azure_functions_langgraph._handlers import _method_accepts_version
+
+        def fn(input: Any, config: Any = None) -> None: ...
+
+        assert _method_accepts_version(fn) is False
+
+    def test_method_uninspectable_returns_false(self) -> None:
+        from azure_functions_langgraph._handlers import _method_accepts_version
+
+        # ``print`` is a builtin whose signature cannot be introspected.
+        assert _method_accepts_version(print) is False
+
+    def test_resolve_returns_empty_when_no_version(self) -> None:
+        from azure_functions_langgraph._handlers import _resolve_version_kwarg
+
+        def fn(input: Any, **kwargs: Any) -> None: ...
+
+        assert _resolve_version_kwarg(fn, None, "agent") == {}
+
+    def test_resolve_forwards_supported_version(self) -> None:
+        from azure_functions_langgraph._handlers import _resolve_version_kwarg
+
+        def fn(input: Any, **kwargs: Any) -> None: ...
+
+        assert _resolve_version_kwarg(fn, "v2", "agent") == {"version": "v2"}
+
+    def test_resolve_rejects_unsupported_graph(self) -> None:
+        from azure_functions_langgraph._handlers import _resolve_version_kwarg
+
+        def fn(input: Any, config: Any = None) -> None: ...
+
+        result = _resolve_version_kwarg(fn, "v2", "agent")
+        assert isinstance(result, func.HttpResponse)
+        assert result.status_code == 422
+        body = json.loads(result.get_body())
+        assert "version" in body["detail"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,7 @@ Issue: #41
 
 from __future__ import annotations
 
+from importlib.metadata import version as _pkg_version
 import json
 import operator
 from typing import Annotated, Any, TypedDict
@@ -16,8 +17,27 @@ from typing import Annotated, Any, TypedDict
 import azure.functions as func
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
+import pytest
 
 from azure_functions_langgraph.app import LangGraphApp
+
+
+def _langgraph_supports_v2() -> bool:
+    """``version='v2'`` requires langgraph>=1.1 (GraphOutput / StreamPart)."""
+    parts = _pkg_version("langgraph").split(".")
+    try:
+        major, minor = int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):  # pragma: no cover - defensive
+        return False
+    return (major, minor) >= (1, 1)
+
+
+_requires_v2 = pytest.mark.skipif(
+    not _langgraph_supports_v2(),
+    reason="langgraph<1.1 does not support version='v2'",
+)
+
+
 
 # ---------------------------------------------------------------------------
 # Graph state & deterministic nodes
@@ -462,6 +482,7 @@ class TestNativeStreamState:
 class TestNativeVersionPassthrough:
     """Forwarding the optional ``version`` field to invoke/stream (#423)."""
 
+    @_requires_v2
     def test_invoke_v2_returns_graph_output_envelope(self) -> None:
         """version='v2' invoke returns the GraphOutput {value, interrupts} shape."""
         saver = MemorySaver()
@@ -510,6 +531,7 @@ class TestNativeVersionPassthrough:
         assert output["last_reply"] == "Hello, Alice!"
         assert output["turn_count"] == 1
 
+    @_requires_v2
     def test_stream_v2_emits_streampart_frames(self) -> None:
         """version='v2' stream yields StreamPart dicts (type/ns/data/interrupts)."""
         saver = MemorySaver()


### PR DESCRIPTION
## Context
Closes #423. LangGraph 1.1+ accepts a `version="v1"|"v2"` argument on `invoke`/`stream`/`ainvoke`/`astream` that changes the output shape (v2 wraps results in a `GraphOutput` envelope and emits `StreamPart` dicts). This wires that through the native endpoints without changing defaults.

## Changes
- **Contracts**: add `LangGraphVersion = Literal["v1", "v2"]` alias and an optional `version` field on `InvokeRequest`/`StreamRequest` (and both envelope builders).
- **Handlers**: forward `version` to `invoke`/`stream` **only when provided**. Capability is detected structurally via `inspect.signature` (`_method_accepts_version` / `_resolve_version_kwarg`); a graph that cannot accept `version` returns a helpful **422** instead of crashing, so `version` stays off the base `LangGraphLike` protocol.
- **Example**: new deployable `examples/versioned_output_agent/` documenting the v2 output/StreamPart shape difference.
- **Tests**: handler-level tests for default vs v2 invoke/stream, invalid-version 422, and unit tests for the capability helpers.

## Verification
- `make lint`, `make typecheck` clean (73 source files)
- `make test` — 1071 passed, coverage **96.20%** (≥95% gate)

## Out of scope
- Changing the default invoke/stream version.
- Async handlers (tracked in #422).