### PR TITLE
feat(native): native async invoke/stream via ainvoke/astream (#422)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@
 | OpenAPI bridge (isolated) | [`openapi_bridge`](openapi_bridge/) | Minimal echo graph showing `register_with_openapi` wiring in isolation. For the bridge on a **real agent**, see `tool_calling_agent`. |
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |
 | Versioned output | [`versioned_output_agent`](versioned_output_agent/) | Opt into LangGraph's `version="v2"` unified `GraphOutput` / `StreamPart` shapes via the request contract. |
+| Async agent | [`async_agent`](async_agent/) | Serve a graph with `async def` nodes through the native async path (`async_mode=True` → `await ainvoke`/`astream`). |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
 | Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
 
@@ -51,4 +52,5 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 - **Want OpenAPI / Swagger UI on a real agent?** → `tool_calling_agent` (bridge wired into a tool-calling agent); **just the bridge in isolation?** → `openapi_bridge`
 - **Mixing public and private graphs?** → `production_auth`
 - **Verifying a deployed Function App from the terminal?** → `local_curl`
+- **Serving a graph with async nodes (`await` real I/O)?** → `async_agent`
 - **Recovering orphaned run locks automatically?** → `maintenance_timer`

--- a/examples/async_agent/README.md
+++ b/examples/async_agent/README.md
@@ -1,0 +1,90 @@
+# Async Agent Example
+
+Demonstrates the native **async execution surface** (issue #422). The graph's
+nodes are `async def` coroutines, and the app registers the graph with
+`async_mode=True` so the native `invoke`/`stream` endpoints `await`
+`graph.ainvoke` / `graph.astream` instead of the synchronous methods.
+
+The node logic is deterministic — no LLM calls — so the example runs in CI
+without any cloud credentials. The `await asyncio.sleep(0)` in each node stands
+in for real awaitable I/O (an async HTTP client, an async DB driver, etc.).
+
+## Why async?
+
+- **`async_mode=True`** routes the endpoints through async Azure Functions
+  handlers that `await` the graph on the worker's event loop.
+- The per-thread lock (used when the graph has a checkpointer and the request
+  carries a `thread_id`) is offloaded with `asyncio.to_thread`, so a blocking
+  distributed lock backend never stalls the event loop.
+- A `CompiledStateGraph` exposes **both** sync and async methods, so the same
+  graph still works on the default (sync) path — the flag just selects which
+  method the handlers call. A graph exposing **only** async methods is served
+  async automatically, with or without the flag.
+
+## Prerequisites
+
+- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) v4+
+- Python 3.10+
+- `langgraph>=1.1`
+
+## Run locally
+
+```bash
+cd examples/async_agent
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+## Test
+
+### Invoke
+
+`invoke` awaits `graph.ainvoke` and returns the graph's final state under
+`output`:
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/async_agent/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"user_text": "Ada", "history": [], "turn_count": 0}}'
+```
+
+```json
+{"output": {"user_text": "Ada", "history": ["Hello, Ada!"], "turn_count": 1, "last_reply": "Hello, Ada!"}}
+```
+
+### Stream
+
+`stream` consumes `graph.astream` with `async for` and flushes buffered SSE
+frames after the run completes:
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/async_agent/stream \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"user_text": "Ada", "history": [], "turn_count": 0}, "stream_mode": "values"}'
+```
+
+```
+event: data
+data: {"user_text": "Ada", "history": [], "turn_count": 0}
+
+event: data
+data: {"user_text": "Ada", "history": ["Hello, Ada!"], "turn_count": 0, "last_reply": "Hello, Ada!"}
+
+event: data
+data: {"user_text": "Ada", "history": ["Hello, Ada!"], "turn_count": 1, "last_reply": "Hello, Ada!"}
+
+event: end
+data: {}
+```
+
+> **Streaming is buffered SSE.** As with every `/stream` endpoint in this
+> package, chunks are collected during execution and flushed after the run
+> completes. `async_mode` changes **how the graph is called** (awaited), not the
+> buffering behavior.
+
+### Health check
+
+```bash
+curl http://localhost:7071/api/health
+```

--- a/examples/async_agent/function_app.py
+++ b/examples/async_agent/function_app.py
@@ -1,0 +1,19 @@
+"""Async agent - Azure Functions entry point.
+
+Run from this directory:
+    func start
+"""
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+
+langgraph_app = LangGraphApp()
+langgraph_app.register(
+    graph=compiled_graph,
+    name="async_agent",
+    description="A deterministic agent served through the native async (ainvoke/astream) path",
+    async_mode=True,
+)
+
+app = langgraph_app.function_app

--- a/examples/async_agent/graph.py
+++ b/examples/async_agent/graph.py
@@ -1,0 +1,89 @@
+"""Async agent example: serve a graph through the async invoke/stream path.
+
+This example demonstrates the **native async execution surface** (issue #422).
+The graph's nodes are ``async def`` coroutines, and the app registers the graph
+with ``async_mode=True`` so the native ``invoke``/``stream`` endpoints ``await``
+``graph.ainvoke`` / ``graph.astream`` instead of the synchronous methods.
+
+The node logic is deliberately deterministic — no LLM calls — so the example
+runs in CI without any cloud credentials. ``await asyncio.sleep(0)`` stands in
+for real awaitable I/O (an async HTTP client, an async DB driver, etc.).
+
+* ``async_mode=True`` → the endpoints route through the async handlers, which
+  ``await`` the graph and offload the per-thread lock to a worker thread so a
+  blocking distributed lock backend never stalls the event loop.
+* A ``CompiledStateGraph`` exposes **both** sync and async methods, so the same
+  graph still works with the default (sync) path; the flag simply selects which
+  method the handlers call.
+
+Requirements::
+
+    pip install azure-functions-langgraph "langgraph>=1.1"
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from typing_extensions import TypedDict
+
+# ------------------------------------------------------------------
+# 1. Define state
+# ------------------------------------------------------------------
+
+
+class ChatState(TypedDict, total=False):
+    user_text: str
+    history: list[str]
+    turn_count: int
+    last_reply: str
+
+
+# ------------------------------------------------------------------
+# 2. Define async node functions
+# ------------------------------------------------------------------
+
+
+async def greet(state: ChatState) -> dict[str, Any]:
+    """First node — build a greeting after awaiting simulated async I/O."""
+    await asyncio.sleep(0)  # stand-in for a real ``await`` (HTTP, DB, ...)
+    text = state.get("user_text", "")
+    reply = f"Hello, {text}!" if text else "Hello!"
+    return {"history": [*state.get("history", []), reply], "last_reply": reply}
+
+
+async def count(state: ChatState) -> dict[str, Any]:
+    """Second node — increment the turn counter."""
+    await asyncio.sleep(0)
+    return {"turn_count": (state.get("turn_count") or 0) + 1}
+
+
+# ------------------------------------------------------------------
+# 3. Build the graph (using LangGraph API)
+# ------------------------------------------------------------------
+
+# NOTE: This block is guarded so the module can be imported without langgraph
+# installed (e.g. for testing the example structure).
+try:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(ChatState)
+    builder.add_node("greet", greet)
+    builder.add_node("count", count)
+    builder.add_edge(START, "greet")
+    builder.add_edge("greet", "count")
+    builder.add_edge("count", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError:
+    raise ImportError(
+        "langgraph is required for this example. "
+        "Install it with: pip install 'langgraph>=1.1' langchain-core"
+    )

--- a/examples/async_agent/host.json
+++ b/examples/async_agent/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/async_agent/local.settings.json.example
+++ b/examples/async_agent/local.settings.json.example
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}

--- a/examples/async_agent/requirements.txt
+++ b/examples/async_agent/requirements.txt
@@ -1,0 +1,8 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph==0.1.0a0
+# async invoke/stream (ainvoke/astream) works on any supported LangGraph version
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
         StreamRequest,
     )
     from azure_functions_langgraph.protocols import (
+        AsyncInvocableGraph,
+        AsyncStreamableGraph,
         CloneableGraph,
         InvocableGraph,
         LangGraphLike,
@@ -50,7 +52,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RouteMetadata": ("azure_functions_langgraph.contracts", "RouteMetadata"),
     # Protocols
     "InvocableGraph": ("azure_functions_langgraph.protocols", "InvocableGraph"),
+    "AsyncInvocableGraph": ("azure_functions_langgraph.protocols", "AsyncInvocableGraph"),
     "StreamableGraph": ("azure_functions_langgraph.protocols", "StreamableGraph"),
+    "AsyncStreamableGraph": ("azure_functions_langgraph.protocols", "AsyncStreamableGraph"),
     "LangGraphLike": ("azure_functions_langgraph.protocols", "LangGraphLike"),
     "StatefulGraph": ("azure_functions_langgraph.protocols", "StatefulGraph"),
     "CloneableGraph": ("azure_functions_langgraph.protocols", "CloneableGraph"),
@@ -96,7 +100,9 @@ __all__ = [
     "RouteMetadata",
     # Protocols
     "InvocableGraph",
+    "AsyncInvocableGraph",
     "StreamableGraph",
+    "AsyncStreamableGraph",
     "LangGraphLike",
     "StatefulGraph",
     "CloneableGraph",

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -8,6 +8,7 @@ receives only the explicit dependencies it needs — no reference to
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import inspect
 import json
@@ -29,7 +30,11 @@ from azure_functions_langgraph.contracts import (
     StreamRequest,
 )
 from azure_functions_langgraph.locks import ThreadLock
-from azure_functions_langgraph.protocols import StatefulGraph, StreamableGraph
+from azure_functions_langgraph.protocols import (
+    AsyncStreamableGraph,
+    StatefulGraph,
+    StreamableGraph,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -377,6 +382,183 @@ def handle_stream(
         },
     )
 
+
+# ------------------------------------------------------------------
+# Async invoke handler
+# ------------------------------------------------------------------
+
+
+async def handle_invoke_async(
+    req: func.HttpRequest,
+    reg: Any,
+    *,
+    thread_lock: ThreadLock,
+    max_request_body_bytes: int,
+    max_input_depth: int,
+    max_input_nodes: int,
+) -> func.HttpResponse:
+    """Handle an invoke request against an async graph via ``ainvoke``.
+
+    Mirrors :func:`handle_invoke` exactly (validation, thread-lock, error, and
+    response semantics) but awaits ``reg.graph.ainvoke`` and offloads the sync
+    thread-lock calls to a worker thread so a blocking lock backend (e.g. the
+    Azure Blob lease) never stalls the event loop.
+    """
+    parsed = _parse_native_request(
+        req,
+        InvokeRequest,
+        max_request_body_bytes=max_request_body_bytes,
+        max_input_depth=max_input_depth,
+        max_input_nodes=max_input_nodes,
+    )
+    if isinstance(parsed, func.HttpResponse):
+        return parsed
+    request = parsed
+
+    config = request.config or {}
+    thread_id, cfg_err = _extract_thread_id(config)
+    if cfg_err:
+        return _error_response(400, cfg_err)
+    version_kwargs = _resolve_version_kwarg(reg.graph.ainvoke, request.version, reg.name)
+    if isinstance(version_kwargs, func.HttpResponse):
+        return version_kwargs
+    has_cp = getattr(reg.graph, "checkpointer", None) is not None
+    lock_token: str | None = None
+    if has_cp and thread_id:
+        lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
+        if not lock_token:
+            return _error_response(
+                409, f"Thread {thread_id!r} is currently in use by another request"
+            )
+    try:
+        result = await reg.graph.ainvoke(request.input, config=config, **version_kwargs)
+    except Exception as exc:
+        logger.exception("Graph %s ainvoke failed", reg.name)
+        _ = exc
+        return _error_response(500, "Graph execution failed")
+    finally:
+        if lock_token is not None and thread_id is not None:
+            await asyncio.to_thread(thread_lock.release, reg.name, thread_id, lock_token)
+
+    output = _serialize_graph_output(result)
+    response = InvokeResponse(output=output)
+    return func.HttpResponse(
+        body=response.model_dump_json(),
+        mimetype="application/json",
+        status_code=200,
+    )
+
+
+# ------------------------------------------------------------------
+# Async stream handler
+# ------------------------------------------------------------------
+
+
+async def handle_stream_async(
+    req: func.HttpRequest,
+    reg: Any,
+    *,
+    thread_lock: ThreadLock,
+    max_stream_response_bytes: int,
+    max_request_body_bytes: int,
+    max_input_depth: int,
+    max_input_nodes: int,
+) -> func.HttpResponse:
+    """Handle a streaming request against an async graph via ``astream``.
+
+    Async counterpart of :func:`handle_stream`: returns the same **buffered**
+    SSE response (issue #378) built by consuming ``reg.graph.astream`` with
+    ``async for``. The byte-size cap is enforced mid-stream, and the thread
+    lock is released in ``finally`` even when the async generator raises.
+    """
+    if not reg.stream_enabled:
+        return _error_response(501, f"Graph {reg.name!r} is configured as invoke-only")
+
+    if not isinstance(reg.graph, AsyncStreamableGraph):
+        return _error_response(501, f"Graph {reg.name!r} does not support streaming")
+
+    parsed = _parse_native_request(
+        req,
+        StreamRequest,
+        max_request_body_bytes=max_request_body_bytes,
+        max_input_depth=max_input_depth,
+        max_input_nodes=max_input_nodes,
+    )
+    if isinstance(parsed, func.HttpResponse):
+        return parsed
+    request = parsed
+
+    config = request.config or {}
+    thread_id, cfg_err = _extract_thread_id(config)
+    if cfg_err:
+        return _error_response(400, cfg_err)
+    version_kwargs = _resolve_version_kwarg(reg.graph.astream, request.version, reg.name)
+    if isinstance(version_kwargs, func.HttpResponse):
+        return version_kwargs
+    has_cp = getattr(reg.graph, "checkpointer", None) is not None
+    lock_token: str | None = None
+    if has_cp and thread_id:
+        lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
+        if not lock_token:
+            return _error_response(
+                409, f"Thread {thread_id!r} is currently in use by another request"
+            )
+
+    chunks: list[str] = []
+    buffered_bytes = 0
+
+    def _append_chunk(chunk: str) -> bool:
+        nonlocal buffered_bytes
+        chunk_bytes = len(chunk.encode())
+        if buffered_bytes + chunk_bytes > max_stream_response_bytes:
+            error_payload = json.dumps(
+                {
+                    "error": (
+                        "stream response exceeded max buffered size "
+                        f"({max_stream_response_bytes} bytes)"
+                    )
+                }
+            )
+            chunks.append(f"event: error\ndata: {error_payload}\n\n")
+            return False
+        chunks.append(chunk)
+        buffered_bytes += chunk_bytes
+        return True
+
+    try:
+        async for event in reg.graph.astream(
+            request.input,
+            config=config,
+            stream_mode=request.stream_mode,
+            **version_kwargs,
+        ):
+            serialized = json.dumps(
+                event if isinstance(event, dict) else {"data": str(event)},
+                default=str,
+                allow_nan=False,
+            )
+            if not _append_chunk(f"event: data\ndata: {serialized}\n\n"):
+                break
+    except Exception as exc:
+        logger.exception("Graph %s astream failed", reg.name)
+        _ = exc
+        error_payload = json.dumps({"error": "stream processing failed"})
+        _append_chunk(f"event: error\ndata: {error_payload}\n\n")
+    finally:
+        if lock_token is not None and thread_id is not None:
+            await asyncio.to_thread(thread_lock.release, reg.name, thread_id, lock_token)
+
+    _append_chunk("event: end\ndata: {}\n\n")
+
+    return func.HttpResponse(
+        body="".join(chunks),
+        mimetype="text/event-stream",
+        status_code=200,
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 # ------------------------------------------------------------------
 # State handler

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -16,8 +16,10 @@ from azure_functions_langgraph._endpoint import (
 )
 from azure_functions_langgraph._handlers import (
     handle_invoke,
-    handle_state,
+    handle_invoke_async,
+handle_state,
     handle_stream,
+    handle_stream_async,
 )
 from azure_functions_langgraph._metadata import (
     LangGraphMetadata,
@@ -40,7 +42,11 @@ RegisteredGraphMetadata,
     build_stream_request_model,
 )
 from azure_functions_langgraph.locks import InProcessThreadLock, ThreadLock
-from azure_functions_langgraph.protocols import InvocableGraph, StatefulGraph
+from azure_functions_langgraph.protocols import (
+    AsyncInvocableGraph,
+    InvocableGraph,
+    StatefulGraph,
+)
 
 # Route path templates (single source of truth for both function_app and metadata)
 _ROUTE_PREFIX = "/api"
@@ -71,6 +77,7 @@ class _GraphRegistration:
     name: str
     description: Optional[str] = None
     stream_enabled: bool = True
+    async_mode: bool = False
     auth_level: Optional[func.AuthLevel] = None
     request_model: Optional[type[Any]] = None
     response_model: Optional[type[Any]] = None
@@ -299,8 +306,9 @@ class LangGraphApp:
         stream: bool = True,
         auth_level: Optional[func.AuthLevel] = None,
         *,
-        request_model: Optional[type[Any]] = None,
+request_model: Optional[type[Any]] = None,
         response_model: Optional[type[Any]] = None,
+        async_mode: bool = False,
     ) -> None:
         """Register a compiled LangGraph graph.
 
@@ -314,8 +322,15 @@ class LangGraphApp:
                 When ``None`` (default), the app-level ``auth_level`` is used.
             request_model: Optional Pydantic model class for request body
                 (used by the metadata / bridge API, not for runtime validation).
-            response_model: Optional Pydantic model class for response body
+response_model: Optional Pydantic model class for response body
                 (used by the metadata / bridge API, not for runtime validation).
+            async_mode: When ``True``, route this graph's invoke/stream endpoints
+                through async Azure Functions handlers that ``await`` the graph's
+                ``ainvoke`` / ``astream`` methods. Defaults to ``False`` (the sync
+                path), so existing ``CompiledStateGraph`` deployments — which expose
+                both sync and async methods — keep their current behavior. A graph
+                that exposes only async methods is always served async, regardless
+                of this flag.
 
         Raises:
             TypeError: If *graph* does not satisfy the required protocol, or if
@@ -323,8 +338,18 @@ class LangGraphApp:
                 Pydantic ``BaseModel`` subclass.
             ValueError: If *name* is already registered or invalid.
         """
-        if not isinstance(graph, InvocableGraph):
-            raise TypeError(f"Graph must have an invoke() method. Got {type(graph).__name__}")
+        has_sync_invoke = isinstance(graph, InvocableGraph)
+        has_async_invoke = isinstance(graph, AsyncInvocableGraph)
+        if async_mode and not has_async_invoke:
+            raise TypeError(
+                "async_mode=True requires an ainvoke() method. "
+                f"Got {type(graph).__name__}"
+            )
+        if not has_sync_invoke and not has_async_invoke:
+            raise TypeError(
+                "Graph must have an invoke() or ainvoke() method. "
+                f"Got {type(graph).__name__}"
+            )
         _validate_optional_model(request_model, "request_model")
         _validate_optional_model(response_model, "response_model")
         name_err = validate_graph_name(name)
@@ -337,6 +362,7 @@ class LangGraphApp:
             name=name,
             description=description,
             stream_enabled=stream,
+            async_mode=async_mode,
             auth_level=auth_level,
             request_model=request_model,
             response_model=response_model,
@@ -422,15 +448,19 @@ class LangGraphApp:
                 status_code=200,
             )
 
-        # Per-graph endpoints
+# Per-graph endpoints
         for reg in self._registrations.values():
+            is_async = self._is_async(reg)
             self._register_route(
                 app,
                 reg,
                 endpoint="invoke",
                 route_template=_ROUTE_INVOKE,
                 methods=["POST"],
-                handler_impl=self._handle_invoke,
+                handler_impl=(
+                    self._handle_invoke_async if is_async else self._handle_invoke
+                ),
+                is_async=is_async,
             )
             if self._has_stream_route(reg):
                 self._register_route(
@@ -439,7 +469,10 @@ class LangGraphApp:
                     endpoint="stream",
                     route_template=_ROUTE_STREAM,
                     methods=["POST"],
-                    handler_impl=self._handle_stream,
+                    handler_impl=(
+                        self._handle_stream_async if is_async else self._handle_stream
+                    ),
+                    is_async=is_async,
                 )
             if self._has_state_route(reg):
                 self._register_route(
@@ -481,6 +514,16 @@ class LangGraphApp:
         """Whether a graph exposes a thread-state endpoint (single source of truth)."""
         return isinstance(reg.graph, StatefulGraph)
 
+    @staticmethod
+    def _is_async(reg: _GraphRegistration) -> bool:
+        """Whether a graph is served through the async invoke/stream handlers.
+
+        True when the operator opted in with ``async_mode=True`` or when the
+        graph exposes only async methods (no sync ``invoke``), so a pure-async
+        graph is auto-routed to the awaiting handlers.
+        """
+        return reg.async_mode or not isinstance(reg.graph, InvocableGraph)
+
     def _register_route(
         self,
         app: func.FunctionApp,
@@ -489,16 +532,32 @@ class LangGraphApp:
         endpoint: str,
         route_template: str,
         methods: list[str],
-        handler_impl: Callable[[func.HttpRequest, _GraphRegistration], func.HttpResponse],
+        handler_impl: Callable[..., Any],
+        is_async: bool = False,
     ) -> None:
-        """Register one per-graph HTTP route, wiring metadata and auth uniformly."""
+        """Register one per-graph HTTP route, wiring metadata and auth uniformly.
+
+        When *is_async* is ``True``, *handler_impl* is a coroutine function and
+        the registered Azure Functions handler is a real ``async def`` so the
+        worker awaits it on its event loop; otherwise a plain sync handler is
+        registered.
+        """
         route = route_template.format(name=reg.name)
         fn_name = f"aflg_{reg.name}_{endpoint}"
         captured_reg = reg
         effective_auth = self._effective_auth_level(reg)
 
-        def handler(req: func.HttpRequest) -> func.HttpResponse:
-            return handler_impl(req, captured_reg)
+        async def async_handler(req: func.HttpRequest) -> func.HttpResponse:
+            result: func.HttpResponse = await handler_impl(req, captured_reg)
+            return result
+
+        def sync_handler(req: func.HttpRequest) -> func.HttpResponse:
+            result: func.HttpResponse = handler_impl(req, captured_reg)
+            return result
+
+        handler: Callable[[func.HttpRequest], Any] = (
+            async_handler if is_async else sync_handler
+        )
 
         _payload: LangGraphMetadata = {
             "version": 1,
@@ -553,12 +612,45 @@ class LangGraphApp:
             max_input_nodes=self.max_input_nodes,
         )
 
+    async def _handle_invoke_async(
+        self, req: func.HttpRequest, reg: _GraphRegistration
+    ) -> func.HttpResponse:
+        """Handle an invoke request against an async graph via ``ainvoke``."""
+        thread_lock = self.thread_lock
+        if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
+            raise RuntimeError("thread_lock is None; __post_init__ did not run")
+        return await handle_invoke_async(
+            req,
+            reg,
+            thread_lock=thread_lock,
+            max_request_body_bytes=self.max_request_body_bytes,
+            max_input_depth=self.max_input_depth,
+            max_input_nodes=self.max_input_nodes,
+        )
+
     def _handle_stream(self, req: func.HttpRequest, reg: _GraphRegistration) -> func.HttpResponse:
         """Handle a streaming request."""
         thread_lock = self.thread_lock
         if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
             raise RuntimeError("thread_lock is None; __post_init__ did not run")
         return handle_stream(
+            req,
+            reg,
+            thread_lock=thread_lock,
+            max_stream_response_bytes=self.max_stream_response_bytes,
+            max_request_body_bytes=self.max_request_body_bytes,
+            max_input_depth=self.max_input_depth,
+            max_input_nodes=self.max_input_nodes,
+        )
+
+    async def _handle_stream_async(
+        self, req: func.HttpRequest, reg: _GraphRegistration
+    ) -> func.HttpResponse:
+        """Handle a streaming request against an async graph via ``astream``."""
+        thread_lock = self.thread_lock
+        if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
+            raise RuntimeError("thread_lock is None; __post_init__ did not run")
+        return await handle_stream_async(
             req,
             reg,
             thread_lock=thread_lock,

--- a/src/azure_functions_langgraph/protocols.py
+++ b/src/azure_functions_langgraph/protocols.py
@@ -6,7 +6,7 @@ without requiring a hard import of ``langgraph``.
 
 from __future__ import annotations
 
-from typing import Any, Iterator, Protocol, runtime_checkable
+from typing import Any, AsyncIterator, Awaitable, Iterator, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -26,6 +26,27 @@ class StreamableGraph(Protocol):
         config: dict[str, Any] | None = ...,
         stream_mode: str = ...,
     ) -> Iterator[Any]: ...
+
+
+@runtime_checkable
+class AsyncInvocableGraph(Protocol):
+    """Protocol for a graph that supports asynchronous invocation."""
+
+    def ainvoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = ...
+    ) -> Awaitable[Any]: ...
+
+
+@runtime_checkable
+class AsyncStreamableGraph(Protocol):
+    """Protocol for a graph that supports asynchronous streaming."""
+
+    def astream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = ...,
+        stream_mode: str = ...,
+    ) -> AsyncIterator[Any]: ...
 
 
 @runtime_checkable

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -21,6 +21,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("cosmos_checkpoint_azure", "compiled_graph"),
     ("production_persistent_agent", "compiled_graph"),
     ("versioned_output_agent", "compiled_graph"),
+    ("async_agent", "compiled_graph"),
 )
 
 
@@ -73,6 +74,7 @@ EXAMPLE_DIRS = (
     "cosmos_checkpoint_azure",
     "production_persistent_agent",
     "versioned_output_agent",
+    "async_agent",
 )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,9 +9,11 @@ Issue: #41
 
 from __future__ import annotations
 
+import asyncio
 from importlib.metadata import version as _pkg_version
 import json
 import operator
+import types
 from typing import Annotated, Any, TypedDict
 
 import azure.functions as func
@@ -19,7 +21,9 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 import pytest
 
+from azure_functions_langgraph._handlers import handle_stream_async
 from azure_functions_langgraph.app import LangGraphApp
+from azure_functions_langgraph.locks import InProcessThreadLock
 
 
 def _langgraph_supports_v2() -> bool:
@@ -103,6 +107,17 @@ def _post(url: str, body: dict[str, Any], **route_params: str) -> func.HttpReque
         method="POST",
         url=url,
         body=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        route_params=route_params,
+    )
+
+
+def _raw_post(url: str, raw: bytes, **route_params: str) -> func.HttpRequest:
+    """POST with an arbitrary (possibly malformed) raw body."""
+    return func.HttpRequest(
+        method="POST",
+        url=url,
+        body=raw,
         headers={"Content-Type": "application/json"},
         route_params=route_params,
     )
@@ -635,3 +650,436 @@ class TestVersionKwargHelpers:
         assert result.status_code == 422
         body = json.loads(result.get_body())
         assert "version" in body["detail"]
+
+
+
+# ---------------------------------------------------------------------------
+# Async graph fakes & helpers (#422)
+# ---------------------------------------------------------------------------
+
+
+class _PureAsyncGraph:
+    """Async-only graph: exposes ``ainvoke``/``astream`` but no sync methods."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = None
+        self.calls: list[str] = []
+
+    async def ainvoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        await asyncio.sleep(0)
+        self.calls.append("ainvoke")
+        text = input.get("user_text", "")
+        return {"last_reply": f"Async, {text}!", "turn_count": 1}
+
+    async def astream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+        **kwargs: Any,
+    ) -> Any:
+        await asyncio.sleep(0)
+        self.calls.append("astream")
+        text = input.get("user_text", "")
+        yield {"last_reply": f"Async, {text}!"}
+        yield {"turn_count": 1}
+
+
+class _StrictAsyncGraph:
+    """Async-only graph whose ``ainvoke`` does not accept a ``version`` kwarg."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = None
+
+    async def ainvoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        await asyncio.sleep(0)
+        return {"ok": True}
+
+    async def astream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+    ) -> Any:
+        await asyncio.sleep(0)
+        yield {"ok": True}
+
+
+class _FailingAsyncGraph:
+    """Async-only graph whose ``ainvoke``/``astream`` raise mid-execution."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = None
+
+    async def ainvoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        await asyncio.sleep(0)
+        raise RuntimeError("boom")
+
+    async def astream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+        **kwargs: Any,
+    ) -> Any:
+        await asyncio.sleep(0)
+        yield {"partial": True}
+        raise RuntimeError("boom")
+
+
+class _AsyncInvokeOnlyGraph:
+    """Async invoke but no ``astream`` — the stream endpoint must return 501."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = None
+
+    async def ainvoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        await asyncio.sleep(0)
+        return {"ok": True}
+
+
+class _SyncOnlyGraph:
+    """Sync invoke only — ``async_mode=True`` must be rejected."""
+
+    def invoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {}
+
+
+class _NoInvokeGraph:
+    """Neither ``invoke`` nor ``ainvoke`` — registration must fail."""
+
+    def unrelated(self) -> None: ...
+
+
+def _make_async_app(
+    graph: Any, *, name: str = "agent", async_mode: bool = True, **app_kwargs: Any
+) -> LangGraphApp:
+    """Build a LangGraphApp registering *graph* through the async handler path."""
+    app = LangGraphApp(**app_kwargs)
+    app.register(graph=graph, name=name, async_mode=async_mode)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Tests — native async invoke/stream (#422)
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncNativeInvoke:
+    """Async invoke handler via ``ainvoke``."""
+
+    async def test_async_invoke_real_graph_envelope(self) -> None:
+        """A real graph registered with async_mode=True awaits ainvoke."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Ada", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "a-t1"}},
+            },
+        )
+        resp = await handler(req)
+        assert resp.status_code == 200
+        output = json.loads(resp.get_body())["output"]
+        assert output["last_reply"] == "Hello, Ada!"
+        assert output["turn_count"] == 1
+
+    async def test_pure_async_graph_auto_routes(self) -> None:
+        """A graph with only async methods is auto-routed to the async handler."""
+        graph = _PureAsyncGraph()
+        app = _make_async_app(graph, async_mode=False)  # not opted in
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post("/api/graphs/agent/invoke", {"input": {"user_text": "Bo"}})
+        resp = await handler(req)
+        assert resp.status_code == 200
+        output = json.loads(resp.get_body())["output"]
+        assert output["last_reply"] == "Async, Bo!"
+        assert graph.calls == ["ainvoke"]
+
+    async def test_async_invoke_forwards_version(self) -> None:
+        """``version`` is forwarded when the async graph accepts it."""
+        graph = _PureAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {"input": {"user_text": "Cy"}, "version": "v2"},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 200
+
+    async def test_async_invoke_version_unsupported_graph_422(self) -> None:
+        """A graph whose ainvoke rejects ``version`` yields 422."""
+        graph = _StrictAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {"input": {"user_text": "Di"}, "version": "v2"},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 422
+
+    async def test_async_invoke_graph_failure_returns_500(self) -> None:
+        """An exception from ainvoke maps to a 500 error response."""
+        graph = _FailingAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post("/api/graphs/agent/invoke", {"input": {"user_text": "Ed"}})
+        resp = await handler(req)
+        assert resp.status_code == 500
+
+    async def test_async_invoke_thread_lock_contention_returns_409(self) -> None:
+        """A held thread lock forces the async invoke to 409."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        assert app.thread_lock is not None
+        token = app.thread_lock.acquire("agent", "busy-t")
+        assert token is not None
+        try:
+            req = _post(
+                "/api/graphs/agent/invoke",
+                {
+                    "input": {"user_text": "Fi", "history": [], "turn_count": 0},
+                    "config": {"configurable": {"thread_id": "busy-t"}},
+                },
+            )
+            resp = await handler(req)
+            assert resp.status_code == 409
+        finally:
+            app.thread_lock.release("agent", "busy-t", token)
+
+    async def test_async_invoke_releases_lock(self) -> None:
+        """The async invoke releases the thread lock on success."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {
+                "input": {"user_text": "Gi", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "rel-t"}},
+            },
+        )
+        resp = await handler(req)
+        assert resp.status_code == 200
+        # Lock must be free again after a successful run.
+        assert app.thread_lock is not None
+        token = app.thread_lock.acquire("agent", "rel-t")
+        assert token is not None
+        app.thread_lock.release("agent", "rel-t", token)
+
+
+class TestAsyncNativeStream:
+    """Async stream handler via ``astream``."""
+
+    async def test_async_stream_buffered_sse(self) -> None:
+        """A real graph async_mode=True streams buffered SSE frames."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {
+                "input": {"user_text": "Hu", "history": [], "turn_count": 0},
+                "config": {"configurable": {"thread_id": "a-stream"}},
+                "stream_mode": "values",
+            },
+        )
+        resp = await handler(req)
+        assert resp.status_code == 200
+        assert resp.mimetype == "text/event-stream"
+        frames = _parse_sse_frames(resp.get_body().decode())
+        data_frames = [f for f in frames if f["data"] and isinstance(f["data"], dict)]
+        assert data_frames
+        final = data_frames[-1]["data"]
+        assert final["turn_count"] == 1
+        assert final["last_reply"] == "Hello, Hu!"
+        assert any(f["event"] == "end" for f in frames)
+
+    async def test_async_stream_invoke_only_returns_501(self) -> None:
+        """A graph without ``astream`` returns 501 on the stream endpoint."""
+        graph = _AsyncInvokeOnlyGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {"input": {"user_text": "Io"}, "stream_mode": "values"},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 501
+
+    async def test_async_stream_byte_cap_emits_error_frame(self) -> None:
+        """Exceeding the buffered byte cap emits an SSE error frame."""
+        graph = _PureAsyncGraph()
+        app = _make_async_app(graph, max_stream_response_bytes=10)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {"input": {"user_text": "Jo"}, "stream_mode": "values"},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 200
+        frames = _parse_sse_frames(resp.get_body().decode())
+        assert any(f["event"] == "error" for f in frames)
+
+    async def test_async_stream_failure_emits_error_frame(self) -> None:
+        """An exception raised mid-stream emits an SSE error frame."""
+        graph = _FailingAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {"input": {"user_text": "Ka"}, "stream_mode": "values"},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 200
+        frames = _parse_sse_frames(resp.get_body().decode())
+        error_frames = [f for f in frames if f["event"] == "error"]
+        assert error_frames
+        assert "stream processing failed" in error_frames[0]["data"]["error"]
+
+
+class TestAsyncRegistration:
+    """Registration-time validation for the async path (#422)."""
+
+    def test_async_mode_requires_ainvoke(self) -> None:
+        """``async_mode=True`` on a sync-only graph raises TypeError."""
+        with pytest.raises(TypeError, match="ainvoke"):
+            _make_async_app(_SyncOnlyGraph())
+
+    def test_graph_without_any_invoke_rejected(self) -> None:
+        """A graph with neither invoke nor ainvoke raises TypeError."""
+        with pytest.raises(TypeError, match="invoke"):
+            _make_async_app(_NoInvokeGraph(), async_mode=False)
+
+
+class TestAsyncNativeBranchCoverage:
+    """Error-path branch coverage for the async invoke/stream handlers (#422)."""
+
+    async def test_async_invoke_malformed_json_returns_error(self) -> None:
+        """A malformed JSON body short-circuits async invoke with an error."""
+        graph = _PureAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _raw_post("/api/graphs/agent/invoke", b"{not-json")
+        resp = await handler(req)
+        assert resp.status_code == 400
+
+    async def test_async_invoke_bad_config_returns_400(self) -> None:
+        """A non-object ``config.configurable`` yields 400 on async invoke."""
+        graph = _PureAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        req = _post(
+            "/api/graphs/agent/invoke",
+            {"input": {"user_text": "La"}, "config": {"configurable": "nope"}},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 400
+
+    async def test_async_stream_malformed_json_returns_error(self) -> None:
+        """A malformed JSON body short-circuits async stream with an error."""
+        graph = _PureAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _raw_post("/api/graphs/agent/stream", b"{not-json")
+        resp = await handler(req)
+        assert resp.status_code == 400
+
+    async def test_async_stream_bad_config_returns_400(self) -> None:
+        """A non-object ``config.configurable`` yields 400 on async stream."""
+        graph = _PureAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {"input": {"user_text": "Ma"}, "config": {"configurable": "nope"}},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 400
+
+    async def test_async_stream_version_unsupported_graph_422(self) -> None:
+        """A graph whose astream rejects ``version`` yields 422."""
+        graph = _StrictAsyncGraph()
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        req = _post(
+            "/api/graphs/agent/stream",
+            {"input": {"user_text": "Na"}, "version": "v2"},
+        )
+        resp = await handler(req)
+        assert resp.status_code == 422
+
+    async def test_async_stream_invoke_only_reg_returns_501(self) -> None:
+        """A stream-disabled registration returns 501 (direct handler call)."""
+        reg = types.SimpleNamespace(
+            name="agent", stream_enabled=False, graph=_PureAsyncGraph()
+        )
+        req = _post("/api/graphs/agent/stream", {"input": {"user_text": "Ob"}})
+        resp = await handle_stream_async(
+            req,
+            reg,
+            thread_lock=InProcessThreadLock(),
+            max_stream_response_bytes=1_000_000,
+            max_request_body_bytes=1_000_000,
+            max_input_depth=20,
+            max_input_nodes=1_000,
+        )
+        assert resp.status_code == 501
+
+    async def test_async_stream_thread_lock_contention_returns_409(self) -> None:
+        """A held thread lock forces the async stream to 409."""
+        saver = MemorySaver()
+        graph = _build_graph(checkpointer=saver)
+        app = _make_async_app(graph)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        assert app.thread_lock is not None
+        token = app.thread_lock.acquire("agent", "busy-stream")
+        assert token is not None
+        try:
+            req = _post(
+                "/api/graphs/agent/stream",
+                {
+                    "input": {"user_text": "Pa", "history": [], "turn_count": 0},
+                    "config": {"configurable": {"thread_id": "busy-stream"}},
+                },
+            )
+            resp = await handler(req)
+            assert resp.status_code == 409
+        finally:
+            app.thread_lock.release("agent", "busy-stream", token)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -38,6 +38,8 @@ def test_all_exports() -> None:
     # Protocols
     assert "InvocableGraph" in azure_functions_langgraph.__all__
     assert "StreamableGraph" in azure_functions_langgraph.__all__
+    assert "AsyncInvocableGraph" in azure_functions_langgraph.__all__
+    assert "AsyncStreamableGraph" in azure_functions_langgraph.__all__
     assert "LangGraphLike" in azure_functions_langgraph.__all__
     assert "StatefulGraph" in azure_functions_langgraph.__all__
     assert "CloneableGraph" in azure_functions_langgraph.__all__
@@ -83,6 +85,8 @@ def test_all_contracts_importable() -> None:
 
 def test_all_protocols_importable() -> None:
     from azure_functions_langgraph import (
+        AsyncInvocableGraph,
+        AsyncStreamableGraph,
         CloneableGraph,
         InvocableGraph,
         LangGraphLike,
@@ -95,6 +99,8 @@ def test_all_protocols_importable() -> None:
     assert LangGraphLike is not None
     assert StatefulGraph is not None
     assert CloneableGraph is not None
+    assert AsyncInvocableGraph is not None
+    assert AsyncStreamableGraph is not None
 
 
 def test_invalid_attr_raises() -> None:


### PR DESCRIPTION
## Summary
- Adds `AsyncInvocableGraph` / `AsyncStreamableGraph` protocols (`ainvoke` / `astream`) alongside the existing sync protocols.
- Adds async twin handlers `handle_invoke_async` / `handle_stream_async` that `await` `ainvoke` / `astream`; sync graphs keep the current path (backward compatible).
- Registration detects async capability: `register(..., async_mode=True)` opts in explicitly, and async-only graphs auto-route to the async handler.
- Thread-lock, auth, error, version-forwarding, and buffered-SSE semantics are preserved on the async path; the sync thread-lock is offloaded via `asyncio.to_thread` (acquire + release, in `finally`).

## Example
- New deployable `examples/async_agent/` demonstrating an async graph (async nodes, no external LLM), registered with `async_mode=True` and wired into the examples smoke suite.

## Tests
- New `TestAsyncNativeInvoke`, `TestAsyncNativeStream`, `TestAsyncRegistration`, and `TestAsyncNativeBranchCoverage` covering the async invoke/stream happy paths plus error branches (malformed JSON, bad config, version-unsupported 422, invoke-only 501, thread-lock 409, failure 500).
- `test_public_api.py` asserts the new protocol exports.
- Full suite green locally at **96.34%** coverage (gate: 95%); `make lint` clean.

Closes #422.