### PR TITLE
feat(observability): add RunObserver run-lifecycle contract (#425)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@
 | Per-graph auth | [`production_auth`](production_auth/) | Public health + anonymous demo graph alongside a function-key-protected graph. |
 | Versioned output | [`versioned_output_agent`](versioned_output_agent/) | Opt into LangGraph's `version="v2"` unified `GraphOutput` / `StreamPart` shapes via the request contract. |
 | Async agent | [`async_agent`](async_agent/) | Serve a graph with `async def` nodes through the native async path (`async_mode=True` → `await ainvoke`/`astream`). |
+| Run observability | [`run_observer`](run_observer/) | Wire a pluggable `RunObserver` into `LangGraphApp(observer=...)` — logs run started/completed/failed/rejected with correlation ids and timing only (no payloads). |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
 | Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
 
@@ -53,4 +54,5 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 - **Mixing public and private graphs?** → `production_auth`
 - **Verifying a deployed Function App from the terminal?** → `local_curl`
 - **Serving a graph with async nodes (`await` real I/O)?** → `async_agent`
+- **Observing run lifecycle (started/completed/failed/rejected)?** → `run_observer`
 - **Recovering orphaned run locks automatically?** → `maintenance_timer`

--- a/examples/run_observer/README.md
+++ b/examples/run_observer/README.md
@@ -1,0 +1,103 @@
+# Run Observer Example
+
+Demonstrates the **run-lifecycle observability contract** (issue #425). The app
+registers a pluggable [`RunObserver`](../../src/azure_functions_langgraph/observability.py)
+that is notified across every native `invoke`/`stream` run:
+
+- `on_run_started` — after all pre-execution validation passes, just before the
+  graph is called.
+- `on_run_completed` — after the graph returns successfully.
+- `on_run_failed` — when the graph raises (or a stream exceeds the buffered-size
+  cap).
+- `on_run_rejected` — when a run never reaches the graph (bad request/config,
+  unsupported version, streaming unsupported, or lock contention).
+
+The graph itself is deterministic — no LLM calls — so the example runs in CI
+without any cloud credentials. The interesting part is `function_app.py`, which
+wires a small `LoggingRunObserver` into `LangGraphApp(observer=...)`.
+
+## No payloads, no secrets
+
+The `RunContext` handed to the observer carries **only** correlation identifiers
+(graph name, endpoint, run id, thread id) and monotonic timings — never input,
+output, config, or headers. The example observer therefore logs run metadata
+that is safe to ship to any sink. Concrete exporters (Application Insights,
+OpenTelemetry, KQL) layer on top of this same contract and are tracked
+separately (issue #407).
+
+## Opt-in registration
+
+The observer is an app-level, opt-in kwarg. Omit it and the app uses a no-op
+observer, so wiring an observer never changes HTTP behaviour:
+
+```python
+langgraph_app = LangGraphApp(observer=LoggingRunObserver())
+```
+
+Observer callbacks are isolated — an exception raised inside an observer is
+swallowed and logged, and never changes the HTTP response or interferes with
+thread-lock release.
+
+## Prerequisites
+
+- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) v4+
+- Python 3.10+
+- `langgraph>=1.1`
+
+## Run locally
+
+```bash
+cd examples/run_observer
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+## Test
+
+### Invoke (emits `on_run_started` → `on_run_completed`)
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/run_observer/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"user_text": "Ada", "history": [], "turn_count": 0}}'
+```
+
+```json
+{"output": {"user_text": "Ada", "history": ["Hello, Ada!"], "turn_count": 1, "last_reply": "Hello, Ada!"}}
+```
+
+The Functions host log shows the observer output:
+
+```
+run.started   graph=run_observer endpoint=invoke run_id=... thread_id=None
+run.completed graph=run_observer endpoint=invoke run_id=... thread_id=None elapsed_ms=...
+```
+
+### Rejected run (emits `on_run_rejected`)
+
+Send a malformed body to see the rejection path — the graph is never invoked:
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/run_observer/invoke \
+  -H "Content-Type: application/json" \
+  -d 'not json'
+```
+
+```
+run.rejected graph=run_observer endpoint=invoke run_id=... thread_id=None reason=invalid_request
+```
+
+### Stream (emits `on_run_started` → `on_run_completed`)
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/run_observer/stream \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"user_text": "Ada", "history": [], "turn_count": 0}, "stream_mode": "values"}'
+```
+
+### Health check
+
+```bash
+curl http://localhost:7071/api/health
+```

--- a/examples/run_observer/function_app.py
+++ b/examples/run_observer/function_app.py
@@ -1,0 +1,90 @@
+"""Run-observer example - Azure Functions entry point.
+
+Demonstrates the run-lifecycle observability contract (issue #425): a pluggable
+:class:`RunObserver` is registered on ``LangGraphApp`` and notified across every
+native invoke/stream run (started / completed / failed / rejected).
+
+The observer below logs only **correlation identifiers and timing** — never
+input, output, config, or secrets — mirroring the contract's no-payload
+guarantee. Concrete exporters (Application Insights, OpenTelemetry) layer on top
+of this same contract and are intentionally out of scope here.
+
+Run from this directory:
+    func start
+"""
+
+from __future__ import annotations
+
+import logging
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+from azure_functions_langgraph.observability import RunContext, RunRejectedReason
+
+logger = logging.getLogger("run_observer.example")
+
+
+class LoggingRunObserver:
+    """A minimal :class:`RunObserver` that logs run lifecycle events.
+
+    Emits only correlation identifiers (graph name, endpoint, run id, thread id)
+    and elapsed time — never request/response payloads, config, or secrets — so
+    the logs are safe to ship to any sink.
+    """
+
+    @staticmethod
+    def _elapsed_ms(ctx: RunContext) -> float | None:
+        if ctx.ended_at_ns is None:
+            return None
+        return (ctx.ended_at_ns - ctx.started_at_ns) / 1_000_000
+
+    def on_run_started(self, ctx: RunContext) -> None:
+        logger.info(
+            "run.started graph=%s endpoint=%s run_id=%s thread_id=%s",
+            ctx.graph_name,
+            ctx.endpoint,
+            ctx.run_id,
+            ctx.thread_id,
+        )
+
+    def on_run_completed(self, ctx: RunContext) -> None:
+        logger.info(
+            "run.completed graph=%s endpoint=%s run_id=%s thread_id=%s elapsed_ms=%s",
+            ctx.graph_name,
+            ctx.endpoint,
+            ctx.run_id,
+            ctx.thread_id,
+            self._elapsed_ms(ctx),
+        )
+
+    def on_run_failed(self, ctx: RunContext, exc: BaseException) -> None:
+        logger.error(
+            "run.failed graph=%s endpoint=%s run_id=%s thread_id=%s elapsed_ms=%s error=%s",
+            ctx.graph_name,
+            ctx.endpoint,
+            ctx.run_id,
+            ctx.thread_id,
+            self._elapsed_ms(ctx),
+            type(exc).__name__,
+        )
+
+    def on_run_rejected(self, ctx: RunContext, reason: RunRejectedReason) -> None:
+        logger.warning(
+            "run.rejected graph=%s endpoint=%s run_id=%s thread_id=%s reason=%s",
+            ctx.graph_name,
+            ctx.endpoint,
+            ctx.run_id,
+            ctx.thread_id,
+            reason,
+        )
+
+
+langgraph_app = LangGraphApp(observer=LoggingRunObserver())
+langgraph_app.register(
+    graph=compiled_graph,
+    name="run_observer",
+    description="A deterministic agent with a logging RunObserver wired in (issue #425)",
+)
+
+app = langgraph_app.function_app

--- a/examples/run_observer/graph.py
+++ b/examples/run_observer/graph.py
@@ -1,0 +1,75 @@
+"""Run-observer example: a deterministic graph to exercise run observability.
+
+This example demonstrates the **run-lifecycle observability contract** (issue
+#425). The graph itself is deliberately deterministic — no LLM calls — so the
+example runs in CI without any cloud credentials. The interesting part lives in
+``function_app.py``, which registers a logging :class:`RunObserver` on the app.
+
+Requirements::
+
+    pip install azure-functions-langgraph "langgraph>=1.1"
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+# ------------------------------------------------------------------
+# 1. Define state
+# ------------------------------------------------------------------
+
+
+class ChatState(TypedDict, total=False):
+    user_text: str
+    history: list[str]
+    turn_count: int
+    last_reply: str
+
+
+# ------------------------------------------------------------------
+# 2. Define node functions
+# ------------------------------------------------------------------
+
+
+def greet(state: ChatState) -> dict[str, Any]:
+    """First node — build a greeting."""
+    text = state.get("user_text", "")
+    reply = f"Hello, {text}!" if text else "Hello!"
+    return {"history": [*state.get("history", []), reply], "last_reply": reply}
+
+
+def count(state: ChatState) -> dict[str, Any]:
+    """Second node — increment the turn counter."""
+    return {"turn_count": (state.get("turn_count") or 0) + 1}
+
+
+# ------------------------------------------------------------------
+# 3. Build the graph (using LangGraph API)
+# ------------------------------------------------------------------
+
+# NOTE: This block is guarded so the module can be imported without langgraph
+# installed (e.g. for testing the example structure).
+try:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(ChatState)
+    builder.add_node("greet", greet)
+    builder.add_node("count", count)
+    builder.add_edge(START, "greet")
+    builder.add_edge("greet", "count")
+    builder.add_edge("count", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError:
+    raise ImportError(
+        "langgraph is required for this example. "
+        "Install it with: pip install 'langgraph>=1.1' langchain-core"
+    )

--- a/examples/run_observer/host.json
+++ b/examples/run_observer/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/run_observer/local.settings.json.example
+++ b/examples/run_observer/local.settings.json.example
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}

--- a/examples/run_observer/requirements.txt
+++ b/examples/run_observer/requirements.txt
@@ -1,0 +1,8 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph==0.1.0a0
+# run observability contract works on any supported LangGraph version
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -21,6 +21,12 @@ if TYPE_CHECKING:
         StateResponse,
         StreamRequest,
     )
+    from azure_functions_langgraph.observability import (
+        NoOpRunObserver,
+        RunContext,
+        RunObserver,
+        RunRejectedReason,
+    )
     from azure_functions_langgraph.protocols import (
         AsyncInvocableGraph,
         AsyncStreamableGraph,
@@ -58,6 +64,11 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LangGraphLike": ("azure_functions_langgraph.protocols", "LangGraphLike"),
     "StatefulGraph": ("azure_functions_langgraph.protocols", "StatefulGraph"),
     "CloneableGraph": ("azure_functions_langgraph.protocols", "CloneableGraph"),
+    # Observability
+    "RunObserver": ("azure_functions_langgraph.observability", "RunObserver"),
+    "RunContext": ("azure_functions_langgraph.observability", "RunContext"),
+    "NoOpRunObserver": ("azure_functions_langgraph.observability", "NoOpRunObserver"),
+    "RunRejectedReason": ("azure_functions_langgraph.observability", "RunRejectedReason"),
 }
 
 # Symbols whose import failure means the optional runtime deps are missing;
@@ -106,4 +117,9 @@ __all__ = [
     "LangGraphLike",
     "StatefulGraph",
     "CloneableGraph",
+    # Observability
+    "RunObserver",
+    "RunContext",
+    "NoOpRunObserver",
+    "RunRejectedReason",
 ]

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -30,6 +30,15 @@ from azure_functions_langgraph.contracts import (
     StreamRequest,
 )
 from azure_functions_langgraph.locks import ThreadLock
+from azure_functions_langgraph.observability import (
+    NOOP_OBSERVER,
+    RunContext,
+    RunObserver,
+    RunRejectedReason,
+    finish_context,
+    new_run_context,
+    safe_observer_call,
+)
 from azure_functions_langgraph.protocols import (
     AsyncStreamableGraph,
     StatefulGraph,
@@ -72,6 +81,17 @@ def _error_response(status_code: int, detail: str) -> func.HttpResponse:
         mimetype="application/json",
         status_code=status_code,
     )
+
+
+def _reject(
+    observer: RunObserver,
+    ctx: RunContext,
+    reason: RunRejectedReason,
+    response: func.HttpResponse,
+) -> func.HttpResponse:
+    """Emit ``on_run_rejected`` for a pre-execution rejection and return *response*."""
+    safe_observer_call(observer, "on_run_rejected", finish_context(ctx), reason)
+    return response
 
 
 def _method_accepts_version(method: Any) -> bool:
@@ -222,8 +242,10 @@ def handle_invoke(
     max_request_body_bytes: int,
     max_input_depth: int,
     max_input_nodes: int,
+    observer: RunObserver = NOOP_OBSERVER,
 ) -> func.HttpResponse:
     """Handle a synchronous invoke request."""
+    ctx = new_run_context(reg.name, "invoke")
     parsed = _parse_native_request(
         req,
         InvokeRequest,
@@ -232,34 +254,42 @@ def handle_invoke(
         max_input_nodes=max_input_nodes,
     )
     if isinstance(parsed, func.HttpResponse):
-        return parsed
+        return _reject(observer, ctx, "invalid_request", parsed)
     request = parsed
 
     config = request.config or {}
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
-        return _error_response(400, cfg_err)
+        return _reject(observer, ctx, "invalid_config", _error_response(400, cfg_err))
+    ctx = dataclasses.replace(ctx, thread_id=thread_id)
     version_kwargs = _resolve_version_kwarg(reg.graph.invoke, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
-        return version_kwargs
+        return _reject(observer, ctx, "unsupported_version", version_kwargs)
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = thread_lock.acquire(reg.name, thread_id)
         if not lock_token:
-            return _error_response(
-                409, f"Thread {thread_id!r} is currently in use by another request"
+            return _reject(
+                observer,
+                ctx,
+                "lock_contention",
+                _error_response(
+                    409, f"Thread {thread_id!r} is currently in use by another request"
+                ),
             )
+    safe_observer_call(observer, "on_run_started", ctx)
     try:
         result = reg.graph.invoke(request.input, config=config, **version_kwargs)
     except Exception as exc:
         logger.exception("Graph %s invoke failed", reg.name)
-        _ = exc
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), exc)
         return _error_response(500, "Graph execution failed")
     finally:
         if lock_token is not None and thread_id is not None:
             thread_lock.release(reg.name, thread_id, lock_token)
 
+    safe_observer_call(observer, "on_run_completed", finish_context(ctx))
     output = _serialize_graph_output(result)
     response = InvokeResponse(output=output)
     return func.HttpResponse(
@@ -283,6 +313,7 @@ def handle_stream(
     max_request_body_bytes: int,
     max_input_depth: int,
     max_input_nodes: int,
+    observer: RunObserver = NOOP_OBSERVER,
 ) -> func.HttpResponse:
     """Handle a streaming request.
 
@@ -293,11 +324,22 @@ def handle_stream(
     "Streaming: buffered SSE and the true-streaming migration" section of
     ``DESIGN.md`` for the constraints and migration path.
     """
+    ctx = new_run_context(reg.name, "stream")
     if not reg.stream_enabled:
-        return _error_response(501, f"Graph {reg.name!r} is configured as invoke-only")
+        return _reject(
+            observer,
+            ctx,
+            "streaming_unsupported",
+            _error_response(501, f"Graph {reg.name!r} is configured as invoke-only"),
+        )
 
     if not isinstance(reg.graph, StreamableGraph):
-        return _error_response(501, f"Graph {reg.name!r} does not support streaming")
+        return _reject(
+            observer,
+            ctx,
+            "streaming_unsupported",
+            _error_response(501, f"Graph {reg.name!r} does not support streaming"),
+        )
 
     parsed = _parse_native_request(
         req,
@@ -307,23 +349,29 @@ def handle_stream(
         max_input_nodes=max_input_nodes,
     )
     if isinstance(parsed, func.HttpResponse):
-        return parsed
+        return _reject(observer, ctx, "invalid_request", parsed)
     request = parsed
 
     config = request.config or {}
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
-        return _error_response(400, cfg_err)
+        return _reject(observer, ctx, "invalid_config", _error_response(400, cfg_err))
+    ctx = dataclasses.replace(ctx, thread_id=thread_id)
     version_kwargs = _resolve_version_kwarg(reg.graph.stream, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
-        return version_kwargs
+        return _reject(observer, ctx, "unsupported_version", version_kwargs)
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = thread_lock.acquire(reg.name, thread_id)
         if not lock_token:
-            return _error_response(
-                409, f"Thread {thread_id!r} is currently in use by another request"
+            return _reject(
+                observer,
+                ctx,
+                "lock_contention",
+                _error_response(
+                    409, f"Thread {thread_id!r} is currently in use by another request"
+                ),
             )
 
     chunks: list[str] = []
@@ -347,6 +395,8 @@ def handle_stream(
         buffered_bytes += chunk_bytes
         return True
 
+    stream_error: BaseException | None = None
+    safe_observer_call(observer, "on_run_started", ctx)
     try:
         for event in reg.graph.stream(
             request.input,
@@ -360,10 +410,13 @@ def handle_stream(
                 allow_nan=False,
             )
             if not _append_chunk(f"event: data\ndata: {serialized}\n\n"):
+                stream_error = RuntimeError(
+                    "stream response exceeded max buffered size"
+                )
                 break
     except Exception as exc:
         logger.exception("Graph %s stream failed", reg.name)
-        _ = exc
+        stream_error = exc
         error_payload = json.dumps({"error": "stream processing failed"})
         _append_chunk(f"event: error\ndata: {error_payload}\n\n")
     finally:
@@ -371,6 +424,11 @@ def handle_stream(
             thread_lock.release(reg.name, thread_id, lock_token)
 
     _append_chunk("event: end\ndata: {}\n\n")
+
+    if stream_error is not None:
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), stream_error)
+    else:
+        safe_observer_call(observer, "on_run_completed", finish_context(ctx))
 
     return func.HttpResponse(
         body="".join(chunks),
@@ -396,6 +454,7 @@ async def handle_invoke_async(
     max_request_body_bytes: int,
     max_input_depth: int,
     max_input_nodes: int,
+    observer: RunObserver = NOOP_OBSERVER,
 ) -> func.HttpResponse:
     """Handle an invoke request against an async graph via ``ainvoke``.
 
@@ -404,6 +463,7 @@ async def handle_invoke_async(
     thread-lock calls to a worker thread so a blocking lock backend (e.g. the
     Azure Blob lease) never stalls the event loop.
     """
+    ctx = new_run_context(reg.name, "invoke")
     parsed = _parse_native_request(
         req,
         InvokeRequest,
@@ -412,34 +472,42 @@ async def handle_invoke_async(
         max_input_nodes=max_input_nodes,
     )
     if isinstance(parsed, func.HttpResponse):
-        return parsed
+        return _reject(observer, ctx, "invalid_request", parsed)
     request = parsed
 
     config = request.config or {}
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
-        return _error_response(400, cfg_err)
+        return _reject(observer, ctx, "invalid_config", _error_response(400, cfg_err))
+    ctx = dataclasses.replace(ctx, thread_id=thread_id)
     version_kwargs = _resolve_version_kwarg(reg.graph.ainvoke, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
-        return version_kwargs
+        return _reject(observer, ctx, "unsupported_version", version_kwargs)
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
         if not lock_token:
-            return _error_response(
-                409, f"Thread {thread_id!r} is currently in use by another request"
+            return _reject(
+                observer,
+                ctx,
+                "lock_contention",
+                _error_response(
+                    409, f"Thread {thread_id!r} is currently in use by another request"
+                ),
             )
+    safe_observer_call(observer, "on_run_started", ctx)
     try:
         result = await reg.graph.ainvoke(request.input, config=config, **version_kwargs)
     except Exception as exc:
         logger.exception("Graph %s ainvoke failed", reg.name)
-        _ = exc
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), exc)
         return _error_response(500, "Graph execution failed")
     finally:
         if lock_token is not None and thread_id is not None:
             await asyncio.to_thread(thread_lock.release, reg.name, thread_id, lock_token)
 
+    safe_observer_call(observer, "on_run_completed", finish_context(ctx))
     output = _serialize_graph_output(result)
     response = InvokeResponse(output=output)
     return func.HttpResponse(
@@ -463,6 +531,7 @@ async def handle_stream_async(
     max_request_body_bytes: int,
     max_input_depth: int,
     max_input_nodes: int,
+    observer: RunObserver = NOOP_OBSERVER,
 ) -> func.HttpResponse:
     """Handle a streaming request against an async graph via ``astream``.
 
@@ -471,11 +540,22 @@ async def handle_stream_async(
     ``async for``. The byte-size cap is enforced mid-stream, and the thread
     lock is released in ``finally`` even when the async generator raises.
     """
+    ctx = new_run_context(reg.name, "stream")
     if not reg.stream_enabled:
-        return _error_response(501, f"Graph {reg.name!r} is configured as invoke-only")
+        return _reject(
+            observer,
+            ctx,
+            "streaming_unsupported",
+            _error_response(501, f"Graph {reg.name!r} is configured as invoke-only"),
+        )
 
     if not isinstance(reg.graph, AsyncStreamableGraph):
-        return _error_response(501, f"Graph {reg.name!r} does not support streaming")
+        return _reject(
+            observer,
+            ctx,
+            "streaming_unsupported",
+            _error_response(501, f"Graph {reg.name!r} does not support streaming"),
+        )
 
     parsed = _parse_native_request(
         req,
@@ -485,23 +565,29 @@ async def handle_stream_async(
         max_input_nodes=max_input_nodes,
     )
     if isinstance(parsed, func.HttpResponse):
-        return parsed
+        return _reject(observer, ctx, "invalid_request", parsed)
     request = parsed
 
     config = request.config or {}
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
-        return _error_response(400, cfg_err)
+        return _reject(observer, ctx, "invalid_config", _error_response(400, cfg_err))
+    ctx = dataclasses.replace(ctx, thread_id=thread_id)
     version_kwargs = _resolve_version_kwarg(reg.graph.astream, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
-        return version_kwargs
+        return _reject(observer, ctx, "unsupported_version", version_kwargs)
     has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
         if not lock_token:
-            return _error_response(
-                409, f"Thread {thread_id!r} is currently in use by another request"
+            return _reject(
+                observer,
+                ctx,
+                "lock_contention",
+                _error_response(
+                    409, f"Thread {thread_id!r} is currently in use by another request"
+                ),
             )
 
     chunks: list[str] = []
@@ -525,6 +611,8 @@ async def handle_stream_async(
         buffered_bytes += chunk_bytes
         return True
 
+    stream_error: BaseException | None = None
+    safe_observer_call(observer, "on_run_started", ctx)
     try:
         async for event in reg.graph.astream(
             request.input,
@@ -538,10 +626,13 @@ async def handle_stream_async(
                 allow_nan=False,
             )
             if not _append_chunk(f"event: data\ndata: {serialized}\n\n"):
+                stream_error = RuntimeError(
+                    "stream response exceeded max buffered size"
+                )
                 break
     except Exception as exc:
         logger.exception("Graph %s astream failed", reg.name)
-        _ = exc
+        stream_error = exc
         error_payload = json.dumps({"error": "stream processing failed"})
         _append_chunk(f"event: error\ndata: {error_payload}\n\n")
     finally:
@@ -549,6 +640,11 @@ async def handle_stream_async(
             await asyncio.to_thread(thread_lock.release, reg.name, thread_id, lock_token)
 
     _append_chunk("event: end\ndata: {}\n\n")
+
+    if stream_error is not None:
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), stream_error)
+    else:
+        safe_observer_call(observer, "on_run_completed", finish_context(ctx))
 
     return func.HttpResponse(
         body="".join(chunks),

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -42,6 +42,7 @@ RegisteredGraphMetadata,
     build_stream_request_model,
 )
 from azure_functions_langgraph.locks import InProcessThreadLock, ThreadLock
+from azure_functions_langgraph.observability import NoOpRunObserver, RunObserver
 from azure_functions_langgraph.protocols import (
     AsyncInvocableGraph,
     InvocableGraph,
@@ -224,6 +225,7 @@ class LangGraphApp:
     max_input_nodes: int = 10_000
     platform_compat: bool = False
     thread_lock: Optional[ThreadLock] = None
+    observer: Optional[RunObserver] = None
     route_prefix: str = _ROUTE_PREFIX  # metadata-only; must match host.json routePrefix
     _registrations: dict[str, _GraphRegistration] = field(default_factory=dict)
     _function_app: Optional[func.FunctionApp] = field(default=None, init=False, repr=False)
@@ -281,6 +283,8 @@ class LangGraphApp:
         # a custom one. See azure_functions_langgraph.locks for backend details.
         if self.thread_lock is None:
             self.thread_lock = InProcessThreadLock()
+        if self.observer is None:
+            self.observer = NoOpRunObserver()
         # AZFUNC_LANGGRAPH_LOCK_BACKEND is a safety guard that keeps operators
         # from accidentally deploying an in-process lock to a multi-instance
         # Function App. Set it to ``distributed`` (or the exact backend class
@@ -603,6 +607,7 @@ response_model: Optional Pydantic model class for response body
         thread_lock = self.thread_lock
         if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
             raise RuntimeError("thread_lock is None; __post_init__ did not run")
+        observer = self.observer or NoOpRunObserver()
         return handle_invoke(
             req,
             reg,
@@ -610,6 +615,7 @@ response_model: Optional Pydantic model class for response body
             max_request_body_bytes=self.max_request_body_bytes,
             max_input_depth=self.max_input_depth,
             max_input_nodes=self.max_input_nodes,
+            observer=observer,
         )
 
     async def _handle_invoke_async(
@@ -619,6 +625,7 @@ response_model: Optional Pydantic model class for response body
         thread_lock = self.thread_lock
         if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
             raise RuntimeError("thread_lock is None; __post_init__ did not run")
+        observer = self.observer or NoOpRunObserver()
         return await handle_invoke_async(
             req,
             reg,
@@ -626,6 +633,7 @@ response_model: Optional Pydantic model class for response body
             max_request_body_bytes=self.max_request_body_bytes,
             max_input_depth=self.max_input_depth,
             max_input_nodes=self.max_input_nodes,
+            observer=observer,
         )
 
     def _handle_stream(self, req: func.HttpRequest, reg: _GraphRegistration) -> func.HttpResponse:
@@ -633,6 +641,7 @@ response_model: Optional Pydantic model class for response body
         thread_lock = self.thread_lock
         if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
             raise RuntimeError("thread_lock is None; __post_init__ did not run")
+        observer = self.observer or NoOpRunObserver()
         return handle_stream(
             req,
             reg,
@@ -641,6 +650,7 @@ response_model: Optional Pydantic model class for response body
             max_request_body_bytes=self.max_request_body_bytes,
             max_input_depth=self.max_input_depth,
             max_input_nodes=self.max_input_nodes,
+            observer=observer,
         )
 
     async def _handle_stream_async(
@@ -650,6 +660,7 @@ response_model: Optional Pydantic model class for response body
         thread_lock = self.thread_lock
         if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
             raise RuntimeError("thread_lock is None; __post_init__ did not run")
+        observer = self.observer or NoOpRunObserver()
         return await handle_stream_async(
             req,
             reg,
@@ -658,6 +669,7 @@ response_model: Optional Pydantic model class for response body
             max_request_body_bytes=self.max_request_body_bytes,
             max_input_depth=self.max_input_depth,
             max_input_nodes=self.max_input_nodes,
+            observer=observer,
         )
 
     def _handle_state(self, req: func.HttpRequest, reg: _GraphRegistration) -> func.HttpResponse:

--- a/src/azure_functions_langgraph/observability.py
+++ b/src/azure_functions_langgraph/observability.py
@@ -1,0 +1,135 @@
+"""Run-lifecycle observability contract for native invoke/stream handlers.
+
+This module defines the *foundation* for run observability (issue #425): a
+small, stable :class:`RunObserver` protocol plus an immutable
+:class:`RunContext` carrying graph/thread/run correlation identifiers. It
+deliberately emits **no request/response payloads, config, or secrets** — only
+correlation identifiers and timing.
+
+Concrete exporters (Application Insights, OpenTelemetry, KQL examples) are out
+of scope here and are layered on top of this contract separately (issue #407).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import time
+from typing import Literal, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# The endpoint that produced a run. Kept as a ``Literal`` so downstream
+# exporters can switch on a stable, closed set of values.
+EndpointName = Literal["invoke", "stream"]
+
+# Why a run never reached graph execution. Every value corresponds to a
+# pre-execution failure path in the native handlers; execution-time failures
+# use :meth:`RunObserver.on_run_failed` instead.
+RunRejectedReason = Literal[
+    "invalid_request",
+    "invalid_config",
+    "unsupported_version",
+    "streaming_unsupported",
+    "lock_contention",
+]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RunContext:
+    """Immutable correlation + timing context for a single native run.
+
+    Carries only identifiers and monotonic timings — never input, output,
+    config, or headers — so an observer cannot accidentally leak user payloads
+    or secrets. ``ended_at_ns`` is ``None`` until a terminal event
+    (completed/failed/rejected) is emitted.
+    """
+
+    graph_name: str
+    endpoint: EndpointName
+    run_id: str
+    thread_id: str | None
+    started_at_ns: int
+    ended_at_ns: int | None = None
+
+
+@runtime_checkable
+class RunObserver(Protocol):
+    """Observer notified across a native run's lifecycle.
+
+    Ordering invariant:
+
+    - A run that passes all pre-execution validation emits exactly one
+      :meth:`on_run_started` followed by exactly one terminal event
+      (:meth:`on_run_completed` or :meth:`on_run_failed`).
+    - A run rejected before graph execution (bad request/config/version,
+      streaming unsupported, or lock contention) emits **only**
+      :meth:`on_run_rejected` — with no prior ``on_run_started``.
+
+    Implementations must be cheap and must not raise; the handlers isolate
+    observer exceptions, but a well-behaved observer should not rely on that.
+    """
+
+    def on_run_started(self, ctx: RunContext) -> None: ...
+
+    def on_run_completed(self, ctx: RunContext) -> None: ...
+
+    def on_run_failed(self, ctx: RunContext, exc: BaseException) -> None: ...
+
+    def on_run_rejected(self, ctx: RunContext, reason: RunRejectedReason) -> None: ...
+
+
+class NoOpRunObserver:
+    """Default observer that does nothing.
+
+    Used when no observer is registered on the app, so handlers can always call
+    the observer unconditionally without ``None`` checks.
+    """
+
+    def on_run_started(self, ctx: RunContext) -> None:  # noqa: D102
+        return None
+
+    def on_run_completed(self, ctx: RunContext) -> None:  # noqa: D102
+        return None
+
+    def on_run_failed(self, ctx: RunContext, exc: BaseException) -> None:  # noqa: D102
+        return None
+
+    def on_run_rejected(self, ctx: RunContext, reason: RunRejectedReason) -> None:  # noqa: D102
+        return None
+
+
+# Shared stateless singleton used as the default when no observer is wired.
+NOOP_OBSERVER: RunObserver = NoOpRunObserver()
+
+
+def new_run_context(
+    graph_name: str, endpoint: EndpointName, *, thread_id: str | None = None
+) -> RunContext:
+    """Create a fresh :class:`RunContext` with a unique run id and start time."""
+    from uuid import uuid4
+
+    return RunContext(
+        graph_name=graph_name,
+        endpoint=endpoint,
+        run_id=uuid4().hex,
+        thread_id=thread_id,
+        started_at_ns=time.monotonic_ns(),
+    )
+
+
+def finish_context(ctx: RunContext) -> RunContext:
+    """Return a copy of *ctx* stamped with a terminal ``ended_at_ns``."""
+    return dataclasses.replace(ctx, ended_at_ns=time.monotonic_ns())
+
+
+def safe_observer_call(observer: RunObserver, method: str, *args: object) -> None:
+    """Invoke ``observer.<method>(*args)``, swallowing and logging any error.
+
+    Observer bugs must never change HTTP behaviour or interfere with thread-lock
+    release, so every emission site routes through here.
+    """
+    try:
+        getattr(observer, method)(*args)
+    except Exception:  # noqa: BLE001 - observer isolation is intentional
+        logger.exception("RunObserver.%s raised; ignoring", method)

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -22,6 +22,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("production_persistent_agent", "compiled_graph"),
     ("versioned_output_agent", "compiled_graph"),
     ("async_agent", "compiled_graph"),
+    ("run_observer", "compiled_graph"),
 )
 
 
@@ -75,6 +76,7 @@ EXAMPLE_DIRS = (
     "production_persistent_agent",
     "versioned_output_agent",
     "async_agent",
+    "run_observer",
 )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 import pytest
 
-from azure_functions_langgraph._handlers import handle_stream_async
+from azure_functions_langgraph._handlers import handle_stream, handle_stream_async
 from azure_functions_langgraph.app import LangGraphApp
 from azure_functions_langgraph.locks import InProcessThreadLock
 
@@ -1083,3 +1083,354 @@ class TestAsyncNativeBranchCoverage:
             assert resp.status_code == 409
         finally:
             app.thread_lock.release("agent", "busy-stream", token)
+
+
+# ---------------------------------------------------------------------------
+# Run-lifecycle observability fakes & helpers (#425)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingObserver:
+    """Observer that records every lifecycle event for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[Any, ...]] = []
+
+    def on_run_started(self, ctx: Any) -> None:
+        self.events.append(("started", ctx))
+
+    def on_run_completed(self, ctx: Any) -> None:
+        self.events.append(("completed", ctx))
+
+    def on_run_failed(self, ctx: Any, exc: BaseException) -> None:
+        self.events.append(("failed", ctx, exc))
+
+    def on_run_rejected(self, ctx: Any, reason: str) -> None:
+        self.events.append(("rejected", ctx, reason))
+
+    @property
+    def names(self) -> list[str]:
+        return [event[0] for event in self.events]
+
+
+class _RaisingObserver:
+    """Observer whose every callback raises — must never break a run."""
+
+    def on_run_started(self, ctx: Any) -> None:
+        raise RuntimeError("observer started boom")
+
+    def on_run_completed(self, ctx: Any) -> None:
+        raise RuntimeError("observer completed boom")
+
+    def on_run_failed(self, ctx: Any, exc: BaseException) -> None:
+        raise RuntimeError("observer failed boom")
+
+    def on_run_rejected(self, ctx: Any, reason: str) -> None:
+        raise RuntimeError("observer rejected boom")
+
+
+class _SyncGraph:
+    """Sync graph exposing version-capable ``invoke``/``stream``."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = None
+
+    def invoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        return {"last_reply": "ok", "turn_count": 1}
+
+    def stream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+        **kwargs: Any,
+    ) -> Any:
+        yield {"last_reply": "ok"}
+        yield {"turn_count": 1}
+
+
+class _StrictSyncGraph:
+    """Sync graph whose ``invoke``/``stream`` do not accept ``version``."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = None
+
+    def invoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {"ok": True}
+
+    def stream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+    ) -> Any:
+        yield {"ok": True}
+
+
+class _FailingSyncGraph:
+    """Sync graph whose ``invoke``/``stream`` raise mid-execution."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = None
+
+    def invoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        raise RuntimeError("boom")
+
+    def stream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+        **kwargs: Any,
+    ) -> Any:
+        yield {"partial": True}
+        raise RuntimeError("boom")
+
+
+class _CheckpointedSyncGraph:
+    """Sync graph reporting a checkpointer so the thread lock engages."""
+
+    def __init__(self) -> None:
+        self.checkpointer: Any = object()
+
+    def invoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        return {"ok": True}
+
+
+def _observed_app(graph: Any, observer: Any, **app_kwargs: Any) -> LangGraphApp:
+    """Build a LangGraphApp wired with *observer* and a single registered graph."""
+    app = LangGraphApp(observer=observer, **app_kwargs)
+    app.register(graph=graph, name="agent")
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Tests — run-lifecycle observability (#425)
+# ---------------------------------------------------------------------------
+
+
+class TestObserverSyncInvoke:
+    """Observer emission across the sync invoke handler."""
+
+    def test_success_emits_started_then_completed(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_SyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(_post("/api/graphs/agent/invoke", {"input": {"user_text": "Al"}}))
+        assert resp.status_code == 200
+        assert obs.names == ["started", "completed"]
+        started_ctx = obs.events[0][1]
+        completed_ctx = obs.events[1][1]
+        assert started_ctx.graph_name == "agent"
+        assert started_ctx.endpoint == "invoke"
+        assert started_ctx.run_id == completed_ctx.run_id
+        assert started_ctx.ended_at_ns is None
+        assert completed_ctx.ended_at_ns is not None
+
+    def test_graph_failure_emits_started_then_failed(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_FailingSyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(_post("/api/graphs/agent/invoke", {"input": {"user_text": "Bo"}}))
+        assert resp.status_code == 500
+        assert obs.names == ["started", "failed"]
+        assert isinstance(obs.events[1][2], RuntimeError)
+
+    def test_malformed_json_emits_rejected_only(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_SyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(_raw_post("/api/graphs/agent/invoke", b"{not-json"))
+        assert resp.status_code == 400
+        assert obs.names == ["rejected"]
+        assert obs.events[0][2] == "invalid_request"
+
+    def test_bad_config_emits_rejected_invalid_config(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_SyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(
+            _post(
+                "/api/graphs/agent/invoke",
+                {"input": {"user_text": "Ci"}, "config": {"configurable": "nope"}},
+            )
+        )
+        assert resp.status_code == 400
+        assert obs.names == ["rejected"]
+        assert obs.events[0][2] == "invalid_config"
+
+    def test_unsupported_version_emits_rejected(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_StrictSyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(
+            _post("/api/graphs/agent/invoke", {"input": {"user_text": "Di"}, "version": "v2"})
+        )
+        assert resp.status_code == 422
+        assert obs.names == ["rejected"]
+        assert obs.events[0][2] == "unsupported_version"
+
+    def test_lock_contention_emits_rejected(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_CheckpointedSyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        assert app.thread_lock is not None
+        token = app.thread_lock.acquire("agent", "busy-t")
+        assert token is not None
+        try:
+            resp = handler(
+                _post(
+                    "/api/graphs/agent/invoke",
+                    {
+                        "input": {"user_text": "Ee"},
+                        "config": {"configurable": {"thread_id": "busy-t"}},
+                    },
+                )
+            )
+            assert resp.status_code == 409
+        finally:
+            app.thread_lock.release("agent", "busy-t", token)
+        assert obs.names == ["rejected"]
+        assert obs.events[0][2] == "lock_contention"
+        assert obs.events[0][1].thread_id == "busy-t"
+
+    def test_observer_exceptions_are_isolated(self) -> None:
+        app = _observed_app(_SyncGraph(), _RaisingObserver())
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(_post("/api/graphs/agent/invoke", {"input": {"user_text": "Ef"}}))
+        assert resp.status_code == 200
+
+
+class TestObserverSyncStream:
+    """Observer emission across the sync stream handler."""
+
+    def test_success_emits_started_then_completed(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_SyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        resp = handler(
+            _post(
+                "/api/graphs/agent/stream",
+                {"input": {"user_text": "Fo"}, "stream_mode": "values"},
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "completed"]
+
+    def test_graph_failure_emits_started_then_failed(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_FailingSyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        resp = handler(
+            _post(
+                "/api/graphs/agent/stream",
+                {"input": {"user_text": "Gu"}, "stream_mode": "values"},
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "failed"]
+        assert isinstance(obs.events[1][2], RuntimeError)
+
+    def test_byte_cap_emits_started_then_failed(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_SyncGraph(), obs, max_stream_response_bytes=10)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        resp = handler(
+            _post(
+                "/api/graphs/agent/stream",
+                {"input": {"user_text": "Hy"}, "stream_mode": "values"},
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "failed"]
+
+    def test_streaming_unsupported_emits_rejected_only(self) -> None:
+        obs = _RecordingObserver()
+        reg = types.SimpleNamespace(
+            name="agent", stream_enabled=False, graph=_SyncGraph()
+        )
+        resp = handle_stream(
+            _post("/api/graphs/agent/stream", {"input": {"user_text": "Iz"}}),
+            reg,
+            thread_lock=InProcessThreadLock(),
+            max_stream_response_bytes=1_000_000,
+            max_request_body_bytes=1_000_000,
+            max_input_depth=20,
+            max_input_nodes=1_000,
+            observer=obs,
+        )
+        assert resp.status_code == 501
+        assert obs.names == ["rejected"]
+        assert obs.events[0][2] == "streaming_unsupported"
+
+
+class TestObserverAsync:
+    """Observer emission across the async invoke/stream handlers."""
+
+    async def test_async_invoke_success_emits_started_then_completed(self) -> None:
+        obs = _RecordingObserver()
+        app = LangGraphApp(observer=obs)
+        app.register(graph=_PureAsyncGraph(), name="agent", async_mode=True)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = await handler(_post("/api/graphs/agent/invoke", {"input": {"user_text": "Jo"}}))
+        assert resp.status_code == 200
+        assert obs.names == ["started", "completed"]
+
+    async def test_async_invoke_failure_emits_started_then_failed(self) -> None:
+        obs = _RecordingObserver()
+        app = LangGraphApp(observer=obs)
+        app.register(graph=_FailingAsyncGraph(), name="agent", async_mode=True)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = await handler(_post("/api/graphs/agent/invoke", {"input": {"user_text": "Ko"}}))
+        assert resp.status_code == 500
+        assert obs.names == ["started", "failed"]
+
+    async def test_async_stream_success_emits_completed(self) -> None:
+        obs = _RecordingObserver()
+        app = LangGraphApp(observer=obs)
+        app.register(graph=_PureAsyncGraph(), name="agent", async_mode=True)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        resp = await handler(
+            _post(
+                "/api/graphs/agent/stream",
+                {"input": {"user_text": "Lu"}, "stream_mode": "values"},
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "completed"]
+
+    async def test_async_stream_byte_cap_emits_failed(self) -> None:
+        obs = _RecordingObserver()
+        app = LangGraphApp(observer=obs, max_stream_response_bytes=10)
+        app.register(graph=_PureAsyncGraph(), name="agent", async_mode=True)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        resp = await handler(
+            _post(
+                "/api/graphs/agent/stream",
+                {"input": {"user_text": "Ma"}, "stream_mode": "values"},
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "failed"]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -43,6 +43,11 @@ def test_all_exports() -> None:
     assert "LangGraphLike" in azure_functions_langgraph.__all__
     assert "StatefulGraph" in azure_functions_langgraph.__all__
     assert "CloneableGraph" in azure_functions_langgraph.__all__
+    # Observability
+    assert "RunObserver" in azure_functions_langgraph.__all__
+    assert "RunContext" in azure_functions_langgraph.__all__
+    assert "NoOpRunObserver" in azure_functions_langgraph.__all__
+    assert "RunRejectedReason" in azure_functions_langgraph.__all__
 
 
 def test_contracts_importable() -> None:
@@ -149,3 +154,19 @@ def test_azure_table_thread_store_from_table_client_factory() -> None:
     assert callable(AzureTableThreadStore.from_table_client)
     assert hasattr(AzureTableThreadStore, "from_connection_string")
     assert callable(AzureTableThreadStore.from_connection_string)
+
+
+def test_observability_importable_from_package() -> None:
+    from azure_functions_langgraph import (
+        NoOpRunObserver,
+        RunContext,
+        RunObserver,
+        RunRejectedReason,
+    )
+
+    assert RunObserver is not None
+    assert RunContext is not None
+    assert NoOpRunObserver is not None
+    assert RunRejectedReason is not None
+    # NoOpRunObserver satisfies the RunObserver protocol.
+    assert isinstance(NoOpRunObserver(), RunObserver)


### PR DESCRIPTION
## Summary

Implements #425 — a run-lifecycle observability foundation for the native invoke/stream handlers.

- **`observability.py`** — new `RunObserver` `Protocol` (runtime-checkable) with `on_run_started` / `on_run_completed` / `on_run_failed` / `on_run_rejected`, plus an immutable `RunContext` carrying **only** correlation identifiers (graph name, endpoint, run id, thread id) and monotonic timing — never input, output, config, or secrets. Includes `NoOpRunObserver` (default), `RunRejectedReason` literal, and `new_run_context` / `finish_context` / `safe_observer_call` helpers.
- **Handlers** — all four native handlers (sync + async invoke/stream) emit `started` (only after all pre-execution validation passes) → one terminal `completed`/`failed`, or `rejected` for pre-exec failures (`invalid_request`, `invalid_config`, `unsupported_version`, `streaming_unsupported`, `lock_contention`). Stream byte-cap overflow counts as `failed`.
- **`LangGraphApp`** — new opt-in `observer=` kwarg, defaulting to a no-op so wiring an observer never changes HTTP behaviour. Observer exceptions are swallowed + logged centrally, never affecting the response or thread-lock release.
- **Example** — new deployable `examples/run_observer/` with a `LoggingRunObserver` that logs correlation ids + timing only; wired into the examples smoke suite.

## Scope boundary

Concrete exporters (Application Insights / OpenTelemetry / KQL) are intentionally **out of scope** here and layer on top of this contract separately (#407). No `auth` rejection reason — Azure Functions auth happens before the handler and is not observable in-handler.

## Verification

- `make lint` (ruff + mypy) — clean across 74 source files
- Full coverage run — **96.47%** (gate ≥95%); observability.py fully covered
- 15 new observer tests (sync/async, success/failure/rejection/isolation) + public-API export tests + examples smoke

Closes #425