### PR TITLE
feat(observability): add run telemetry fields + built-in LoggingRunObserver (#407)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,41 @@ app_local = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 > architectural change (tracked separately). If you need real-time token streaming
 > today, run the graph behind a long-running host (e.g. App Service or AKS) instead.
 
+### Run observability
+
+Wire a [`RunObserver`](src/azure_functions_langgraph/observability.py) to receive
+run-lifecycle signals (`started` / `completed` / `failed` / `rejected`) for every
+native invoke/stream run and every Platform `runs/wait` / `runs/stream` run. Each
+callback receives an immutable `RunContext` of **correlation identifiers and
+timing only** — never input, output, config, headers, or secrets.
+
+The package ships a built-in, dependency-free `LoggingRunObserver` for
+zero-boilerplate telemetry:
+
+```python
+import logging
+from azure_functions_langgraph import LangGraphApp, LoggingRunObserver
+
+logging.getLogger("azure_functions_langgraph.observability.run").setLevel(logging.INFO)
+
+app = LangGraphApp(observer=LoggingRunObserver())
+app.register(graph=graph, name="my_agent")
+```
+
+It emits one structured log record per lifecycle event under a single `extra`
+key (`langgraph_run`) — `graph_name`, `endpoint`, `run_id`, `thread_id`,
+`assistant_id`, `stream_mode`, `transport`, `has_checkpointer`, `lock_backend`,
+`duration_ms`, a derived `status`, and (on failure) the exception `error_type`
+(class name only). Azure Functions' Application Insights integration surfaces
+these under `customDimensions`.
+
+> The package owns the **domain signal** only — not log formatting, App Insights
+> ingestion, OpenTelemetry exporters, sampling, or PII redaction. Observer
+> failures are isolated and never fail a graph run. To write your own observer,
+> see [`examples/run_observer/`](examples/run_observer/); for an App Insights +
+> KQL walkthrough, see
+> [`examples/observability_app_insights/`](examples/observability_app_insights/).
+
 ### Per-graph auth
 
 Override app-level auth settings per graph:

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -73,16 +73,54 @@ This creates a layered security model: edge auth and governance in APIM, key-bas
 - [Azure Functions authentication and authorization](https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts)
 
 ## Observability
-### Logging integration (recommended operator instrumentation)
+### Run telemetry with the built-in `RunObserver` (recommended)
 
-This package does not emit structured log fields automatically.
-The following are recommended practices for production observability when building your Function App:
+The package emits **run-lifecycle domain signals** through a pluggable
+[`RunObserver`](../src/azure_functions_langgraph/observability.py). Every native
+invoke/stream run (and every Platform `runs/wait` / `runs/stream` run) notifies
+the observer on `started`, `completed`, `failed`, and `rejected`, carrying an
+immutable `RunContext` of **correlation identifiers and timing only** — never
+input, output, config, headers, or secrets.
+
+For zero-boilerplate telemetry, wire the built-in, dependency-free
+`LoggingRunObserver`:
+
+```python
+import logging
+from azure_functions_langgraph import LangGraphApp, LoggingRunObserver
+
+logging.getLogger("azure_functions_langgraph.observability.run").setLevel(logging.INFO)
+
+app = LangGraphApp(observer=LoggingRunObserver())
+```
+
+It emits one structured log record per lifecycle event under a single `extra`
+key (`langgraph_run`) containing `graph_name`, `endpoint`, `run_id`,
+`thread_id`, `assistant_id`, `stream_mode`, `transport`, `has_checkpointer`,
+`lock_backend`, `duration_ms`, a derived `status`, and — on failure — the
+exception `error_type` (class name only). Azure Functions' native Application
+Insights integration surfaces these fields under `customDimensions`. See
+[`examples/observability_app_insights/`](../examples/observability_app_insights/)
+for a full KQL walkthrough (run count, latency percentiles, error rate, and
+per-thread correlation).
+
+**Boundary.** The package owns the *domain signal* only. It does **not** own log
+formatting, App Insights ingestion, OpenTelemetry exporters, tracer-provider
+setup, sampling policy, or PII redaction — those stay in your logging
+configuration. Observer failures are isolated and can never fail a graph run.
+To write your own observer instead, see
+[`examples/run_observer/`](../examples/run_observer/).
+
+### Custom logging integration
+
+If you also instrument your own nodes, these practices pair well with the
+observer above:
 
 - Emit structured fields (`graph_name`, `thread_id`, `assistant_id`, `run_id`, `status_code`, `duration_ms`).
 - Log explicit lifecycle markers: request received, graph started, graph completed/failed.
 - Include error categories (`validation_error`, `execution_error`, `storage_error`) to simplify alerting.
 
-[`azure-functions-logging-python`](https://github.com/yeongseon/azure-functions-logging-python) provides structured logging helpers that pair well with this package.
+[`azure-functions-logging-python`](https://github.com/yeongseon/azure-functions-logging-python) provides structured logging helpers that pair well with this package — use it to *route/format* the records the observer produces.
 
 ### Application Insights correlation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@
 | Versioned output | [`versioned_output_agent`](versioned_output_agent/) | Opt into LangGraph's `version="v2"` unified `GraphOutput` / `StreamPart` shapes via the request contract. |
 | Async agent | [`async_agent`](async_agent/) | Serve a graph with `async def` nodes through the native async path (`async_mode=True` → `await ainvoke`/`astream`). |
 | Run observability | [`run_observer`](run_observer/) | Wire a pluggable `RunObserver` into `LangGraphApp(observer=...)` — logs run started/completed/failed/rejected with correlation ids and timing only (no payloads). |
+| App Insights telemetry | [`observability_app_insights`](observability_app_insights/) | Ship run telemetry to Azure Application Insights with the built-in `LoggingRunObserver` — structured safe fields plus copy-pasteable KQL queries for run count, latency, error rate, and thread correlation. |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
 | Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
 
@@ -55,4 +56,5 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 - **Verifying a deployed Function App from the terminal?** → `local_curl`
 - **Serving a graph with async nodes (`await` real I/O)?** → `async_agent`
 - **Observing run lifecycle (started/completed/failed/rejected)?** → `run_observer`
+- **Shipping run telemetry to Application Insights (KQL dashboards)?** → `observability_app_insights`
 - **Recovering orphaned run locks automatically?** → `maintenance_timer`

--- a/examples/observability_app_insights/README.md
+++ b/examples/observability_app_insights/README.md
@@ -1,0 +1,180 @@
+# Observability with Application Insights (`LoggingRunObserver`)
+
+This example ships **run telemetry** from your LangGraph endpoints to **Azure
+Application Insights** using the package's built-in, dependency-free
+[`LoggingRunObserver`](../../src/azure_functions_langgraph/observability.py)
+(issue #407).
+
+It is the natural next step after [`run_observer/`](../run_observer/):
+
+| Example | What it shows |
+| --- | --- |
+| [`run_observer`](../run_observer/) | How to **write your own** `RunObserver` from the lifecycle contract. |
+| **`observability_app_insights`** (this one) | How to use the **built-in** `LoggingRunObserver` and query the telemetry in App Insights with KQL. |
+
+## What you get
+
+The built-in observer emits one structured log record per run-lifecycle event
+(`started` / `completed` / `failed` / `rejected`). Every record carries a safe,
+non-sensitive field set under the `langgraph_run` key:
+
+| Field | Meaning |
+| --- | --- |
+| `graph_name` | Registered graph name |
+| `endpoint` | `invoke` or `stream` |
+| `run_id` | Unique per-run correlation id |
+| `thread_id` | Thread id (when the request supplies one) |
+| `assistant_id` | Assistant id (Platform runs) |
+| `stream_mode` | Stream mode for `/stream` runs |
+| `transport` | `buffered` (today) or `streaming` (reserved) |
+| `has_checkpointer` | Whether the graph has a checkpointer |
+| `lock_backend` | Thread-lock backend class name |
+| `duration_ms` | Wall time (terminal events only) |
+| `status` | `started` / `completed` / `failed` / `rejected` |
+| `error_type` | Exception **class name** on failure (never the message) |
+| `reason` | Rejection reason on `rejected` |
+
+> **Safety guarantee.** The observer logs **only** the fields above. It never
+> logs request input, model messages, tool arguments, checkpoint values,
+> config, headers, function keys, or connection strings. Telemetry is
+> best-effort and isolated — an observer error can never fail a graph run.
+
+## Boundary — what this package does and does not own
+
+This package owns the **domain signal** (the run lifecycle events and their safe
+fields). It does **not** own:
+
+- log formatting or the App Insights connection — that is Azure Functions'
+  native Application Insights integration, configured via
+  `APPLICATIONINSIGHTS_CONNECTION_STRING`;
+- OpenTelemetry exporters, tracer-provider setup, or sampling policy;
+- PII redaction policy beyond the no-payload guarantee above.
+
+If you already use the companion
+[`azure-functions-logging`](https://github.com/yeongseon/azure-functions-logging-python)
+package, keep using it for formatting/routing — this observer simply *produces*
+the records; your logging configuration decides where they go.
+
+## Wiring
+
+```python
+import logging
+from azure_functions_langgraph import LangGraphApp, LoggingRunObserver
+
+logging.getLogger("azure_functions_langgraph.observability.run").setLevel(logging.INFO)
+
+app = LangGraphApp(observer=LoggingRunObserver())
+app.register(graph=compiled_graph, name="observability_app_insights")
+func_app = app.function_app
+```
+
+That's it. On Azure, set `APPLICATIONINSIGHTS_CONNECTION_STRING` in your Function
+App settings (the Functions runtime ships Python logs to App Insights
+automatically). The structured `langgraph_run` fields surface in the
+`customDimensions` column of the `traces` table.
+
+## Run locally
+
+```bash
+pip install azure-functions-langgraph "langgraph>=1.1"
+func start
+
+curl -X POST http://localhost:7071/api/graphs/observability_app_insights/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"user_text": "Ada"}}'
+```
+
+You will see records like:
+
+```
+langgraph.run.started {'graph_name': 'observability_app_insights', 'endpoint': 'invoke', 'run_id': '...'}
+langgraph.run.completed {'graph_name': 'observability_app_insights', 'endpoint': 'invoke', 'run_id': '...'}
+```
+
+## KQL queries
+
+Azure Functions' App Insights integration writes Python log records to the
+`traces` table, exposing the observer's structured fields under
+`customDimensions`. Depending on your logging configuration the fields land
+either as flattened `customDimensions` keys (prefixed with `langgraph_run.`) or
+inside the JSON `message`. Both patterns are shown below.
+
+### Run count over time (via `customDimensions`)
+
+```kusto
+traces
+| where customDimensions["langgraph_run.status"] in ("completed", "failed")
+| summarize runs = count() by bin(timestamp, 5m), tostring(customDimensions["langgraph_run.status"])
+| render timechart
+```
+
+### p50 / p95 latency by graph and endpoint
+
+```kusto
+traces
+| where customDimensions["langgraph_run.status"] == "completed"
+| extend graph = tostring(customDimensions["langgraph_run.graph_name"]),
+         endpoint = tostring(customDimensions["langgraph_run.endpoint"]),
+         duration_ms = todouble(customDimensions["langgraph_run.duration_ms"])
+| summarize p50 = percentile(duration_ms, 50),
+            p95 = percentile(duration_ms, 95),
+            runs = count()
+  by graph, endpoint
+| order by p95 desc
+```
+
+### Error rate by `error_type`
+
+```kusto
+traces
+| where customDimensions["langgraph_run.status"] == "failed"
+| extend error_type = tostring(customDimensions["langgraph_run.error_type"]),
+         graph = tostring(customDimensions["langgraph_run.graph_name"])
+| summarize failures = count() by graph, error_type
+| order by failures desc
+```
+
+### Rejections by reason
+
+```kusto
+traces
+| where customDimensions["langgraph_run.status"] == "rejected"
+| extend reason = tostring(customDimensions["langgraph_run.reason"])
+| summarize rejected = count() by reason
+| order by rejected desc
+```
+
+### Correlate all events for one thread
+
+```kusto
+traces
+| where customDimensions["langgraph_run.thread_id"] == "conversation-1"
+| extend status = tostring(customDimensions["langgraph_run.status"]),
+         run_id = tostring(customDimensions["langgraph_run.run_id"]),
+         endpoint = tostring(customDimensions["langgraph_run.endpoint"])
+| project timestamp, run_id, endpoint, status
+| order by timestamp asc
+```
+
+### Alternative — fields embedded as JSON in `message`
+
+If your logging setup serialises the `extra` dict into the message instead of
+flattening it into `customDimensions`, parse the JSON first:
+
+```kusto
+traces
+| where message has "langgraph.run"
+| extend run = parse_json(tostring(customDimensions["langgraph_run"]))
+| where tostring(run.status) == "completed"
+| summarize p95 = percentile(todouble(run.duration_ms), 95) by tostring(run.graph_name)
+```
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `graph.py` | Deterministic two-node graph (no LLM, CI-friendly). |
+| `function_app.py` | Wires the built-in `LoggingRunObserver` onto `LangGraphApp`. |
+| `host.json` | Enables the App Insights sampling defaults. |
+| `requirements.txt` | Runtime dependencies. |
+| `local.settings.json.example` | Local settings template. |

--- a/examples/observability_app_insights/function_app.py
+++ b/examples/observability_app_insights/function_app.py
@@ -1,0 +1,51 @@
+"""App Insights observability example - Azure Functions entry point.
+
+Demonstrates shipping run telemetry to **Azure Application Insights** using the
+package's built-in, dependency-free
+:class:`~azure_functions_langgraph.observability.LoggingRunObserver` (issue
+#407).
+
+Unlike ``examples/run_observer/`` — which shows how to *write your own*
+:class:`RunObserver` — this example uses the observer that ships **inside** the
+package. You wire it once and Azure Functions' native Application Insights
+integration picks up the structured log records automatically; the ``README.md``
+next to this file shows the KQL queries that turn those records into
+dashboards.
+
+Key properties (all guaranteed by the built-in observer):
+
+- Emits **only** correlation identifiers, timing, and run metadata — never
+  input, output, config, headers, or secrets.
+- Observer failures are isolated and never fail the graph run.
+- Structured fields are attached under a single ``extra`` key
+  (``langgraph_run``) so they surface in App Insights ``customDimensions``.
+
+This package owns the *domain signal* (the run lifecycle events). It does not
+own log formatting, App Insights ingestion, sampling policy, or PII redaction —
+those remain the platform's / your logging configuration's responsibility.
+
+Run from this directory:
+    func start
+"""
+
+from __future__ import annotations
+
+import logging
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp, LoggingRunObserver
+
+# The built-in observer logs on ``azure_functions_langgraph.observability.run``
+# by default. Emit INFO so started/completed/rejected records reach App
+# Insights (failures are always logged at ERROR regardless of this level).
+logging.getLogger("azure_functions_langgraph.observability.run").setLevel(logging.INFO)
+
+langgraph_app = LangGraphApp(observer=LoggingRunObserver())
+langgraph_app.register(
+    graph=compiled_graph,
+    name="observability_app_insights",
+    description="A deterministic agent shipping run telemetry to App Insights (issue #407)",
+)
+
+app = langgraph_app.function_app

--- a/examples/observability_app_insights/graph.py
+++ b/examples/observability_app_insights/graph.py
@@ -1,0 +1,78 @@
+"""App Insights observability example: a deterministic graph.
+
+This example demonstrates shipping run telemetry to **Azure Application
+Insights** using the package's built-in, dependency-free
+:class:`~azure_functions_langgraph.observability.LoggingRunObserver` (issue
+#407). The graph itself is deliberately deterministic — no LLM calls — so the
+example runs in CI without any cloud credentials. The interesting part lives in
+``function_app.py``, which wires the built-in observer, and in ``README.md``,
+which shows the KQL queries that turn the emitted logs into dashboards.
+
+Requirements::
+
+    pip install azure-functions-langgraph "langgraph>=1.1"
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+# ------------------------------------------------------------------
+# 1. Define state
+# ------------------------------------------------------------------
+
+
+class ChatState(TypedDict, total=False):
+    user_text: str
+    history: list[str]
+    turn_count: int
+    last_reply: str
+
+
+# ------------------------------------------------------------------
+# 2. Define node functions
+# ------------------------------------------------------------------
+
+
+def greet(state: ChatState) -> dict[str, Any]:
+    """First node — build a greeting."""
+    text = state.get("user_text", "")
+    reply = f"Hello, {text}!" if text else "Hello!"
+    return {"history": [*state.get("history", []), reply], "last_reply": reply}
+
+
+def count(state: ChatState) -> dict[str, Any]:
+    """Second node — increment the turn counter."""
+    return {"turn_count": (state.get("turn_count") or 0) + 1}
+
+
+# ------------------------------------------------------------------
+# 3. Build the graph (using LangGraph API)
+# ------------------------------------------------------------------
+
+# NOTE: This block is guarded so the module surfaces a clear error if langgraph
+# is not installed.
+try:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(ChatState)
+    builder.add_node("greet", greet)
+    builder.add_node("count", count)
+    builder.add_edge(START, "greet")
+    builder.add_edge("greet", "count")
+    builder.add_edge("count", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError:
+    raise ImportError(
+        "langgraph is required for this example. "
+        "Install it with: pip install 'langgraph>=1.1' langchain-core"
+    )

--- a/examples/observability_app_insights/host.json
+++ b/examples/observability_app_insights/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/observability_app_insights/local.settings.json.example
+++ b/examples/observability_app_insights/local.settings.json.example
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}

--- a/examples/observability_app_insights/requirements.txt
+++ b/examples/observability_app_insights/requirements.txt
@@ -1,0 +1,8 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph==0.1.0a0
+# run observability contract works on any supported LangGraph version
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -22,10 +22,12 @@ if TYPE_CHECKING:
         StreamRequest,
     )
     from azure_functions_langgraph.observability import (
+        LoggingRunObserver,
         NoOpRunObserver,
         RunContext,
         RunObserver,
         RunRejectedReason,
+        RunTransport,
     )
     from azure_functions_langgraph.protocols import (
         AsyncInvocableGraph,
@@ -69,6 +71,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RunContext": ("azure_functions_langgraph.observability", "RunContext"),
     "NoOpRunObserver": ("azure_functions_langgraph.observability", "NoOpRunObserver"),
     "RunRejectedReason": ("azure_functions_langgraph.observability", "RunRejectedReason"),
+    "RunTransport": ("azure_functions_langgraph.observability", "RunTransport"),
+    "LoggingRunObserver": ("azure_functions_langgraph.observability", "LoggingRunObserver"),
 }
 
 # Symbols whose import failure means the optional runtime deps are missing;
@@ -122,4 +126,6 @@ __all__ = [
     "RunContext",
     "NoOpRunObserver",
     "RunRejectedReason",
+    "RunTransport",
+    "LoggingRunObserver",
 ]

--- a/src/azure_functions_langgraph/_handlers.py
+++ b/src/azure_functions_langgraph/_handlers.py
@@ -245,7 +245,13 @@ def handle_invoke(
     observer: RunObserver = NOOP_OBSERVER,
 ) -> func.HttpResponse:
     """Handle a synchronous invoke request."""
-    ctx = new_run_context(reg.name, "invoke")
+    has_cp = getattr(reg.graph, "checkpointer", None) is not None
+    ctx = new_run_context(
+        reg.name,
+        "invoke",
+        has_checkpointer=has_cp,
+        lock_backend=type(thread_lock).__name__,
+    )
     parsed = _parse_native_request(
         req,
         InvokeRequest,
@@ -265,7 +271,6 @@ def handle_invoke(
     version_kwargs = _resolve_version_kwarg(reg.graph.invoke, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
         return _reject(observer, ctx, "unsupported_version", version_kwargs)
-    has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = thread_lock.acquire(reg.name, thread_id)
@@ -324,7 +329,13 @@ def handle_stream(
     "Streaming: buffered SSE and the true-streaming migration" section of
     ``DESIGN.md`` for the constraints and migration path.
     """
-    ctx = new_run_context(reg.name, "stream")
+    has_cp = getattr(reg.graph, "checkpointer", None) is not None
+    ctx = new_run_context(
+        reg.name,
+        "stream",
+        has_checkpointer=has_cp,
+        lock_backend=type(thread_lock).__name__,
+    )
     if not reg.stream_enabled:
         return _reject(
             observer,
@@ -356,11 +367,10 @@ def handle_stream(
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
         return _reject(observer, ctx, "invalid_config", _error_response(400, cfg_err))
-    ctx = dataclasses.replace(ctx, thread_id=thread_id)
+    ctx = dataclasses.replace(ctx, thread_id=thread_id, stream_mode=request.stream_mode)
     version_kwargs = _resolve_version_kwarg(reg.graph.stream, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
         return _reject(observer, ctx, "unsupported_version", version_kwargs)
-    has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = thread_lock.acquire(reg.name, thread_id)
@@ -463,7 +473,13 @@ async def handle_invoke_async(
     thread-lock calls to a worker thread so a blocking lock backend (e.g. the
     Azure Blob lease) never stalls the event loop.
     """
-    ctx = new_run_context(reg.name, "invoke")
+    has_cp = getattr(reg.graph, "checkpointer", None) is not None
+    ctx = new_run_context(
+        reg.name,
+        "invoke",
+        has_checkpointer=has_cp,
+        lock_backend=type(thread_lock).__name__,
+    )
     parsed = _parse_native_request(
         req,
         InvokeRequest,
@@ -483,7 +499,6 @@ async def handle_invoke_async(
     version_kwargs = _resolve_version_kwarg(reg.graph.ainvoke, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
         return _reject(observer, ctx, "unsupported_version", version_kwargs)
-    has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
@@ -540,7 +555,13 @@ async def handle_stream_async(
     ``async for``. The byte-size cap is enforced mid-stream, and the thread
     lock is released in ``finally`` even when the async generator raises.
     """
-    ctx = new_run_context(reg.name, "stream")
+    has_cp = getattr(reg.graph, "checkpointer", None) is not None
+    ctx = new_run_context(
+        reg.name,
+        "stream",
+        has_checkpointer=has_cp,
+        lock_backend=type(thread_lock).__name__,
+    )
     if not reg.stream_enabled:
         return _reject(
             observer,
@@ -572,11 +593,10 @@ async def handle_stream_async(
     thread_id, cfg_err = _extract_thread_id(config)
     if cfg_err:
         return _reject(observer, ctx, "invalid_config", _error_response(400, cfg_err))
-    ctx = dataclasses.replace(ctx, thread_id=thread_id)
+    ctx = dataclasses.replace(ctx, thread_id=thread_id, stream_mode=request.stream_mode)
     version_kwargs = _resolve_version_kwarg(reg.graph.astream, request.version, reg.name)
     if isinstance(version_kwargs, func.HttpResponse):
         return _reject(observer, ctx, "unsupported_version", version_kwargs)
-    has_cp = getattr(reg.graph, "checkpointer", None) is not None
     lock_token: str | None = None
     if has_cp and thread_id:
         lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -498,6 +498,7 @@ response_model: Optional Pydantic model class for response body
             deps = PlatformRouteDeps(
                 registrations=self._registrations,
                 thread_store=self._thread_store,
+                observer=self.observer or NoOpRunObserver(),
                 auth_level=self.auth_level,
                 max_stream_response_bytes=self.max_stream_response_bytes,
                 max_request_body_bytes=self.max_request_body_bytes,

--- a/src/azure_functions_langgraph/observability.py
+++ b/src/azure_functions_langgraph/observability.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 # exporters can switch on a stable, closed set of values.
 EndpointName = Literal["invoke", "stream"]
 
+# The transport used to deliver a run's result. ``"buffered"`` is the only
+# transport today (buffered SSE / single JSON response); ``"streaming"`` is
+# reserved so opt-in true HTTP streaming (issue #406) can adopt this contract
+# without a breaking change.
+RunTransport = Literal["buffered", "streaming"]
+
 # Why a run never reached graph execution. Every value corresponds to a
 # pre-execution failure path in the native handlers; execution-time failures
 # use :meth:`RunObserver.on_run_failed` instead.
@@ -51,6 +57,18 @@ class RunContext:
     thread_id: str | None
     started_at_ns: int
     ended_at_ns: int | None = None
+
+    # --- Optional safe correlation metadata (issue #407) -----------------
+    # Every field below is defaulted so the context stays constructible from
+    # positional identifiers alone, and each carries only non-sensitive
+    # correlation data — never payloads, config, headers, or secrets.
+    assistant_id: str | None = None
+    invocation_id: str | None = None
+    stream_mode: str | tuple[str, ...] | None = None
+    transport: RunTransport = "buffered"
+    has_checkpointer: bool | None = None
+    lock_backend: str | None = None
+
 
 
 @runtime_checkable
@@ -103,18 +121,52 @@ class NoOpRunObserver:
 NOOP_OBSERVER: RunObserver = NoOpRunObserver()
 
 
+def _normalize_stream_mode(
+    stream_mode: str | list[str] | tuple[str, ...] | None,
+) -> str | tuple[str, ...] | None:
+    """Coerce a stream-mode value into an immutable, context-safe form.
+
+    Lists are converted to tuples so :class:`RunContext` stays hashable/frozen;
+    strings and ``None`` pass through unchanged.
+    """
+    if isinstance(stream_mode, list):
+        return tuple(stream_mode)
+    return stream_mode
+
+
 def new_run_context(
-    graph_name: str, endpoint: EndpointName, *, thread_id: str | None = None
+    graph_name: str,
+    endpoint: EndpointName,
+    *,
+    run_id: str | None = None,
+    thread_id: str | None = None,
+    assistant_id: str | None = None,
+    invocation_id: str | None = None,
+    stream_mode: str | list[str] | tuple[str, ...] | None = None,
+    transport: RunTransport = "buffered",
+    has_checkpointer: bool | None = None,
+    lock_backend: str | None = None,
 ) -> RunContext:
-    """Create a fresh :class:`RunContext` with a unique run id and start time."""
+    """Create a fresh :class:`RunContext` with a unique run id and start time.
+
+    All keyword arguments are optional safe correlation metadata; unavailable
+    fields simply stay ``None`` (or their default). Pass ``run_id`` to reuse an
+    externally generated id (e.g. a Platform run id) instead of a new one.
+    """
     from uuid import uuid4
 
     return RunContext(
         graph_name=graph_name,
         endpoint=endpoint,
-        run_id=uuid4().hex,
+        run_id=run_id or uuid4().hex,
         thread_id=thread_id,
         started_at_ns=time.monotonic_ns(),
+        assistant_id=assistant_id,
+        invocation_id=invocation_id,
+        stream_mode=_normalize_stream_mode(stream_mode),
+        transport=transport,
+        has_checkpointer=has_checkpointer,
+        lock_backend=lock_backend,
     )
 
 
@@ -133,3 +185,112 @@ def safe_observer_call(observer: RunObserver, method: str, *args: object) -> Non
         getattr(observer, method)(*args)
     except Exception:  # noqa: BLE001 - observer isolation is intentional
         logger.exception("RunObserver.%s raised; ignoring", method)
+
+
+def _duration_ms(ctx: RunContext) -> float | None:
+    """Return the run's elapsed wall time in milliseconds, if terminated."""
+    if ctx.ended_at_ns is None:
+        return None
+    return (ctx.ended_at_ns - ctx.started_at_ns) / 1_000_000
+
+
+def _safe_fields(ctx: RunContext, **extra: object) -> dict[str, object]:
+    """Build the safe, structured field set logged for a run.
+
+    Contains only correlation identifiers, timing, and run metadata — never
+    input, output, config, headers, or secrets. Extra derived fields (status,
+    error_type) are merged in by the caller.
+    """
+    fields: dict[str, object] = {
+        "graph_name": ctx.graph_name,
+        "endpoint": ctx.endpoint,
+        "run_id": ctx.run_id,
+        "thread_id": ctx.thread_id,
+        "assistant_id": ctx.assistant_id,
+        "invocation_id": ctx.invocation_id,
+        "stream_mode": ctx.stream_mode,
+        "transport": ctx.transport,
+        "has_checkpointer": ctx.has_checkpointer,
+        "lock_backend": ctx.lock_backend,
+        "duration_ms": _duration_ms(ctx),
+    }
+    fields.update(extra)
+    return fields
+
+
+class LoggingRunObserver:
+    """A dependency-free :class:`RunObserver` backed by stdlib ``logging``.
+
+    Emits one log record per lifecycle event carrying only safe correlation
+    metadata (graph/run/thread/assistant ids, endpoint, transport, stream mode,
+    checkpointer/lock backend, timing) plus a derived ``status`` — and, for
+    failures, the exception ``error_type`` (class name only). It deliberately
+    logs **no** request/response payloads, config, headers, or secrets.
+
+    The observer owns neither log formatting nor handler/exporter configuration:
+    it writes structured fields under a single ``extra`` key so operators can
+    route them to Application Insights / OpenTelemetry / any sink via their own
+    logging configuration (e.g. the companion ``azure-functions-logging``
+    package). See ``examples/observability_app_insights/`` for a KQL walkthrough.
+
+    Args:
+        logger: Logger to emit on. Defaults to
+            ``azure_functions_langgraph.observability.run``.
+        level: Level for non-error events (started/completed/rejected).
+            Failures are always logged at ``logging.ERROR``.
+    """
+
+    _EXTRA_KEY = "langgraph_run"
+
+    def __init__(
+        self,
+        logger: logging.Logger | None = None,
+        *,
+        level: int = logging.INFO,
+    ) -> None:
+        self._logger = logger or logging.getLogger(f"{__name__}.run")
+        self._level = level
+
+    def _emit(
+        self, level: int, message: str, ctx: RunContext, **extra: object
+    ) -> None:
+        self._logger.log(
+            level,
+            message,
+            self._safe_message_args(ctx, extra),
+            extra={self._EXTRA_KEY: _safe_fields(ctx, **extra)},
+        )
+
+    @staticmethod
+    def _safe_message_args(ctx: RunContext, extra: dict[str, object]) -> dict[str, object]:
+        # Compact human-readable summary interpolated into the log message.
+        return {
+            "graph_name": ctx.graph_name,
+            "endpoint": ctx.endpoint,
+            "run_id": ctx.run_id,
+            **extra,
+        }
+
+    def on_run_started(self, ctx: RunContext) -> None:
+        self._emit(self._level, "langgraph.run.started %s", ctx, status="started")
+
+    def on_run_completed(self, ctx: RunContext) -> None:
+        self._emit(self._level, "langgraph.run.completed %s", ctx, status="completed")
+
+    def on_run_failed(self, ctx: RunContext, exc: BaseException) -> None:
+        self._emit(
+            logging.ERROR,
+            "langgraph.run.failed %s",
+            ctx,
+            status="failed",
+            error_type=type(exc).__name__,
+        )
+
+    def on_run_rejected(self, ctx: RunContext, reason: RunRejectedReason) -> None:
+        self._emit(
+            self._level,
+            "langgraph.run.rejected %s",
+            ctx,
+            status="rejected",
+            reason=reason,
+        )

--- a/src/azure_functions_langgraph/platform/_common.py
+++ b/src/azure_functions_langgraph/platform/_common.py
@@ -15,6 +15,7 @@ from azure_functions_langgraph._validation import (
     validate_graph_name,
     validate_input_structure,
 )
+from azure_functions_langgraph.observability import NOOP_OBSERVER, RunObserver
 from azure_functions_langgraph.platform._sse import format_end_event, format_error_event
 from azure_functions_langgraph.platform.contracts import (
     Assistant,
@@ -522,6 +523,7 @@ class PlatformRouteDeps:
     __slots__ = (
         "registrations",
         "thread_store",
+        "observer",
         "auth_level",
         "max_stream_response_bytes",
         "max_request_body_bytes",
@@ -534,6 +536,7 @@ class PlatformRouteDeps:
         *,
         registrations: dict[str, Any],
         thread_store: ThreadStore,
+        observer: RunObserver = NOOP_OBSERVER,
         auth_level: func.AuthLevel,
         max_stream_response_bytes: int,
         max_request_body_bytes: int = 1024 * 1024,
@@ -542,6 +545,7 @@ class PlatformRouteDeps:
     ) -> None:
         self.registrations = registrations
         self.thread_store = thread_store
+        self.observer = observer
         self.auth_level = auth_level
         self.max_stream_response_bytes = max_stream_response_bytes
         self.max_request_body_bytes = max_request_body_bytes

--- a/src/azure_functions_langgraph/platform/_runs.py
+++ b/src/azure_functions_langgraph/platform/_runs.py
@@ -9,6 +9,11 @@ import azure.functions as func
 from azure_functions_langgraph._validation import (
     validate_thread_id,
 )
+from azure_functions_langgraph.observability import (
+    finish_context,
+    new_run_context,
+    safe_observer_call,
+)
 from azure_functions_langgraph.platform._common import (
     PlatformRouteDeps,
     _build_sse_response,
@@ -82,6 +87,16 @@ def register_run_routes(
         if isinstance(reg, func.HttpResponse):
             return reg
 
+        run_id = str(uuid.uuid4())
+        ctx = new_run_context(
+            reg.name,
+            "invoke",
+            run_id=run_id,
+            thread_id=thread_id,
+            assistant_id=run_req.assistant_id,
+            has_checkpointer=getattr(reg.graph, "checkpointer", None) is not None,
+        )
+
         try:
             locked = deps.thread_store.try_acquire_run_lock(
                 thread_id,
@@ -92,6 +107,9 @@ def register_run_routes(
         except ValueError as exc:
             return _platform_error(409, str(exc))
         if locked is None:
+            safe_observer_call(
+                deps.observer, "on_run_rejected", finish_context(ctx), "lock_contention"
+            )
             return _platform_error(
                 409,
                 f"Thread {thread_id!r} is already busy. "
@@ -101,21 +119,23 @@ def register_run_routes(
         config = _build_threaded_config(run_req, thread_id)
 
         graph_input = run_req.input or {}
+        safe_observer_call(deps.observer, "on_run_started", ctx)
         try:
             result = reg.graph.invoke(graph_input, config=config)
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "Graph %s invoke failed for thread %s",
                 run_req.assistant_id,
                 thread_id,
             )
             _release_thread_run_lock(deps, thread_id, status="error")
+            safe_observer_call(deps.observer, "on_run_failed", finish_context(ctx), exc)
             return _platform_error(500, "Graph execution failed")
 
         output = result if isinstance(result, dict) else {"result": result}
         _release_thread_run_lock(deps, thread_id, status="idle", values=output)
+        safe_observer_call(deps.observer, "on_run_completed", finish_context(ctx))
 
-        run_id = str(uuid.uuid4())
         return func.HttpResponse(
             body=json.dumps(output, default=str),
             mimetype="application/json",
@@ -158,6 +178,16 @@ def register_run_routes(
                 f"Graph {run_req.assistant_id!r} does not support streaming",
             )
 
+        run_id = str(uuid.uuid4())
+        ctx = new_run_context(
+            reg.name,
+            "stream",
+            run_id=run_id,
+            thread_id=thread_id,
+            assistant_id=run_req.assistant_id,
+            has_checkpointer=getattr(reg.graph, "checkpointer", None) is not None,
+            stream_mode=stream_mode,
+        )
         try:
             locked = deps.thread_store.try_acquire_run_lock(
                 thread_id,
@@ -168,6 +198,9 @@ def register_run_routes(
         except ValueError as exc:
             return _platform_error(409, str(exc))
         if locked is None:
+            safe_observer_call(
+                deps.observer, "on_run_rejected", finish_context(ctx), "lock_contention"
+            )
             return _platform_error(
                 409,
                 f"Thread {thread_id!r} is already busy. "
@@ -176,7 +209,6 @@ def register_run_routes(
 
         config = _build_threaded_config(run_req, thread_id)
 
-        run_id = str(uuid.uuid4())
 
         graph_input = run_req.input or {}
         chunks: list[str] = []
@@ -186,9 +218,16 @@ def register_run_routes(
         meta_chunk = format_metadata_event(run_id)
         chunks.append(meta_chunk)
         buffered_bytes += len(meta_chunk.encode())
+        safe_observer_call(deps.observer, "on_run_started", ctx)
 
         if _check_stream_overflow(chunks, buffered_bytes, 0, max_bytes):
             _release_thread_run_lock(deps, thread_id, status="error")
+            safe_observer_call(
+                deps.observer,
+                "on_run_failed",
+                finish_context(ctx),
+                RuntimeError("stream response exceeded max buffered size"),
+            )
             return _build_sse_response(
                 chunks,
                 content_location=f"/api/threads/{thread_id}/runs/{run_id}",
@@ -203,19 +242,26 @@ def register_run_routes(
                 chunk_bytes = len(chunk.encode())
                 if _check_stream_overflow(chunks, buffered_bytes, chunk_bytes, max_bytes):
                     _release_thread_run_lock(deps, thread_id, status="error")
+                    safe_observer_call(
+                        deps.observer,
+                        "on_run_failed",
+                        finish_context(ctx),
+                        RuntimeError("stream response exceeded max buffered size"),
+                    )
                     return _build_sse_response(
                         chunks,
                         content_location=f"/api/threads/{thread_id}/runs/{run_id}",
                     )
                 chunks.append(chunk)
                 buffered_bytes += chunk_bytes
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "Graph %s stream failed for thread %s",
                 run_req.assistant_id,
                 thread_id,
             )
             _release_thread_run_lock(deps, thread_id, status="error")
+            safe_observer_call(deps.observer, "on_run_failed", finish_context(ctx), exc)
             chunks.append(format_error_event("stream processing failed"))
             chunks.append(format_end_event())
             return _build_sse_response(
@@ -226,6 +272,7 @@ def register_run_routes(
         chunks.append(format_end_event())
 
         _release_thread_run_lock(deps, thread_id, status="idle")
+        safe_observer_call(deps.observer, "on_run_completed", finish_context(ctx))
 
         return _build_sse_response(
             chunks,
@@ -256,19 +303,29 @@ def register_run_routes(
         if isinstance(config, func.HttpResponse):
             return config
 
+        run_id = str(uuid.uuid4())
+        ctx = new_run_context(
+            reg.name,
+            "invoke",
+            run_id=run_id,
+            assistant_id=run_req.assistant_id,
+            has_checkpointer=False,
+        )
         graph_input = run_req.input or {}
+        safe_observer_call(deps.observer, "on_run_started", ctx)
         try:
             result = exec_graph.invoke(graph_input, config=config)
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "Graph %s invoke failed (threadless)",
                 run_req.assistant_id,
             )
+            safe_observer_call(deps.observer, "on_run_failed", finish_context(ctx), exc)
             return _platform_error(500, "Graph execution failed")
 
         output = result if isinstance(result, dict) else {"result": result}
+        safe_observer_call(deps.observer, "on_run_completed", finish_context(ctx))
 
-        run_id = str(uuid.uuid4())
         return func.HttpResponse(
             body=json.dumps(output, default=str),
             mimetype="application/json",
@@ -311,6 +368,14 @@ def register_run_routes(
             return config
 
         run_id = str(uuid.uuid4())
+        ctx = new_run_context(
+            reg.name,
+            "stream",
+            run_id=run_id,
+            assistant_id=run_req.assistant_id,
+            has_checkpointer=False,
+            stream_mode=stream_mode,
+        )
 
         graph_input = run_req.input or {}
         chunks: list[str] = []
@@ -320,8 +385,15 @@ def register_run_routes(
         meta_chunk = format_metadata_event(run_id)
         chunks.append(meta_chunk)
         buffered_bytes += len(meta_chunk.encode())
+        safe_observer_call(deps.observer, "on_run_started", ctx)
 
         if _check_stream_overflow(chunks, buffered_bytes, 0, max_bytes):
+            safe_observer_call(
+                deps.observer,
+                "on_run_failed",
+                finish_context(ctx),
+                RuntimeError("stream response exceeded max buffered size"),
+            )
             return _build_sse_response(
                 chunks,
                 content_location=f"/api/runs/{run_id}",
@@ -335,18 +407,25 @@ def register_run_routes(
                 chunk = format_data_event(stream_mode, event)
                 chunk_bytes = len(chunk.encode())
                 if _check_stream_overflow(chunks, buffered_bytes, chunk_bytes, max_bytes):
+                    safe_observer_call(
+                        deps.observer,
+                        "on_run_failed",
+                        finish_context(ctx),
+                        RuntimeError("stream response exceeded max buffered size"),
+                    )
                     return _build_sse_response(
                         chunks,
                         content_location=f"/api/runs/{run_id}",
                     )
                 chunks.append(chunk)
                 buffered_bytes += chunk_bytes
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "Graph %s stream failed (threadless)",
                 run_req.assistant_id,
             )
             chunks.append(format_error_event("stream processing failed"))
+            safe_observer_call(deps.observer, "on_run_failed", finish_context(ctx), exc)
             chunks.append(format_end_event())
             return _build_sse_response(
                 chunks,
@@ -354,6 +433,7 @@ def register_run_routes(
             )
 
         chunks.append(format_end_event())
+        safe_observer_call(deps.observer, "on_run_completed", finish_context(ctx))
 
         return _build_sse_response(
             chunks,

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -23,6 +23,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("versioned_output_agent", "compiled_graph"),
     ("async_agent", "compiled_graph"),
     ("run_observer", "compiled_graph"),
+    ("observability_app_insights", "compiled_graph"),
 )
 
 
@@ -77,6 +78,7 @@ EXAMPLE_DIRS = (
     "versioned_output_agent",
     "async_agent",
     "run_observer",
+    "observability_app_insights",
 )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 from importlib.metadata import version as _pkg_version
 import json
+import logging
 import operator
 import types
 from typing import Annotated, Any, TypedDict
@@ -24,6 +25,11 @@ import pytest
 from azure_functions_langgraph._handlers import handle_stream, handle_stream_async
 from azure_functions_langgraph.app import LangGraphApp
 from azure_functions_langgraph.locks import InProcessThreadLock
+from azure_functions_langgraph.observability import (
+    LoggingRunObserver,
+    finish_context,
+    new_run_context,
+)
 
 
 def _langgraph_supports_v2() -> bool:
@@ -1434,3 +1440,181 @@ class TestObserverAsync:
         )
         assert resp.status_code == 200
         assert obs.names == ["started", "failed"]
+
+
+
+# ---------------------------------------------------------------------------
+# Tests — RunContext safe correlation fields (#407)
+# ---------------------------------------------------------------------------
+
+
+class TestObserverContextFields:
+    """The native handlers populate the #407 safe correlation fields on ctx."""
+
+    def test_invoke_ctx_carries_checkpointer_and_lock_backend(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_CheckpointedSyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(
+            _post(
+                "/api/graphs/agent/invoke",
+                {
+                    "input": {"user_text": "Na"},
+                    "config": {"configurable": {"thread_id": "ctx-1"}},
+                },
+            )
+        )
+        assert resp.status_code == 200
+        started_ctx = obs.events[0][1]
+        assert started_ctx.has_checkpointer is True
+        assert started_ctx.lock_backend == "InProcessThreadLock"
+        assert started_ctx.thread_id == "ctx-1"
+        assert started_ctx.transport == "buffered"
+
+    def test_invoke_ctx_without_checkpointer(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_SyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        resp = handler(_post("/api/graphs/agent/invoke", {"input": {"user_text": "No"}}))
+        assert resp.status_code == 200
+        started_ctx = obs.events[0][1]
+        assert started_ctx.has_checkpointer is False
+        assert started_ctx.lock_backend == "InProcessThreadLock"
+        assert started_ctx.stream_mode is None
+
+    def test_stream_ctx_carries_stream_mode(self) -> None:
+        obs = _RecordingObserver()
+        app = _observed_app(_SyncGraph(), obs)
+        handler = _get_fn(app.function_app, "aflg_agent_stream")
+
+        resp = handler(
+            _post(
+                "/api/graphs/agent/stream",
+                {"input": {"user_text": "Pi"}, "stream_mode": "updates"},
+            )
+        )
+        assert resp.status_code == 200
+        started_ctx = obs.events[0][1]
+        assert started_ctx.stream_mode == "updates"
+        assert started_ctx.endpoint == "stream"
+
+
+# ---------------------------------------------------------------------------
+# Tests — LoggingRunObserver (#407)
+# ---------------------------------------------------------------------------
+
+
+_LANGGRAPH_RUN_KEY = "langgraph_run"
+
+
+class TestLoggingRunObserver:
+    """The built-in LoggingRunObserver emits safe, structured log records."""
+
+    def test_started_and_completed_emit_info_with_safe_fields(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        app = _observed_app(_SyncGraph(), LoggingRunObserver())
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        with caplog.at_level(logging.INFO):
+            resp = handler(
+                _post("/api/graphs/agent/invoke", {"input": {"user_text": "Qu"}})
+            )
+        assert resp.status_code == 200
+
+        records = [
+            rec for rec in caplog.records if hasattr(rec, _LANGGRAPH_RUN_KEY)
+        ]
+        assert [rec.levelno for rec in records] == [logging.INFO, logging.INFO]
+        started, completed = (getattr(rec, _LANGGRAPH_RUN_KEY) for rec in records)
+        assert started["status"] == "started"
+        assert started["graph_name"] == "agent"
+        assert started["endpoint"] == "invoke"
+        assert started["duration_ms"] is None
+        assert completed["status"] == "completed"
+        assert completed["duration_ms"] is not None
+        # No payload/config/secret keys must ever leak into the structured fields.
+        forbidden = {"input", "output", "config", "messages", "headers", "result"}
+        assert forbidden.isdisjoint(started.keys())
+        assert forbidden.isdisjoint(completed.keys())
+
+    def test_failure_emits_error_with_error_type(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        app = _observed_app(_FailingSyncGraph(), LoggingRunObserver())
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        with caplog.at_level(logging.INFO):
+            resp = handler(
+                _post("/api/graphs/agent/invoke", {"input": {"user_text": "Re"}})
+            )
+        assert resp.status_code == 500
+
+        records = [
+            rec for rec in caplog.records if hasattr(rec, _LANGGRAPH_RUN_KEY)
+        ]
+        failed = getattr(records[-1], _LANGGRAPH_RUN_KEY)
+        assert records[-1].levelno == logging.ERROR
+        assert failed["status"] == "failed"
+        assert failed["error_type"] == "RuntimeError"
+
+    def test_rejected_emits_reason(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        app = _observed_app(_SyncGraph(), LoggingRunObserver())
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        with caplog.at_level(logging.INFO):
+            resp = handler(_raw_post("/api/graphs/agent/invoke", b"{not-json"))
+        assert resp.status_code == 400
+
+        records = [
+            rec for rec in caplog.records if hasattr(rec, _LANGGRAPH_RUN_KEY)
+        ]
+        rejected = getattr(records[-1], _LANGGRAPH_RUN_KEY)
+        assert rejected["status"] == "rejected"
+        assert rejected["reason"] == "invalid_request"
+
+    def test_custom_logger_and_level_are_honored(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        custom = logging.getLogger("tests.custom.langgraph.run")
+        app = _observed_app(
+            _SyncGraph(), LoggingRunObserver(custom, level=logging.DEBUG)
+        )
+        handler = _get_fn(app.function_app, "aflg_agent_invoke")
+
+        with caplog.at_level(logging.DEBUG, logger="tests.custom.langgraph.run"):
+            resp = handler(
+                _post("/api/graphs/agent/invoke", {"input": {"user_text": "Sy"}})
+            )
+        assert resp.status_code == 200
+        records = [
+            rec
+            for rec in caplog.records
+            if rec.name == "tests.custom.langgraph.run"
+            and hasattr(rec, _LANGGRAPH_RUN_KEY)
+        ]
+        assert records
+        assert all(rec.levelno == logging.DEBUG for rec in records)
+
+
+class TestObservabilityHelpers:
+    """Direct unit coverage for the #407 helper functions."""
+
+    def test_new_run_context_normalizes_list_stream_mode(self) -> None:
+        ctx = new_run_context(
+            "agent", "stream", stream_mode=["values", "updates"]
+        )
+        assert ctx.stream_mode == ("values", "updates")
+        assert ctx.transport == "buffered"
+        assert ctx.ended_at_ns is None
+
+    def test_finish_context_stamps_ended_at(self) -> None:
+        ctx = new_run_context("agent", "invoke")
+        finished = finish_context(ctx)
+        assert finished.ended_at_ns is not None
+        assert finished.ended_at_ns >= finished.started_at_ns
+        assert finished.run_id == ctx.run_id

--- a/tests/test_integration_platform.py
+++ b/tests/test_integration_platform.py
@@ -62,9 +62,10 @@ def _make_platform_app(
     *,
     store: InMemoryThreadStore | None = None,
     name: str = "agent",
+    observer: Any = None,
 ) -> LangGraphApp:
     """Build a LangGraphApp with platform_compat=True."""
-    app = LangGraphApp(platform_compat=True)
+    app = LangGraphApp(platform_compat=True, observer=observer)
     if store is not None:
         app._thread_store = store
     app.register(graph=graph, name=name)
@@ -332,3 +333,136 @@ class TestPlatformState:
         state_req = _get(f"/api/threads/{tid}/state", thread_id=tid)
         state_resp = state_fn(state_req)
         assert state_resp.status_code == 409
+
+
+
+# ---------------------------------------------------------------------------
+# Tests — Platform run-lifecycle observer parity (#407)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingObserver:
+    """Records every lifecycle event for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[Any, ...]] = []
+
+    def on_run_started(self, ctx: Any) -> None:
+        self.events.append(("started", ctx))
+
+    def on_run_completed(self, ctx: Any) -> None:
+        self.events.append(("completed", ctx))
+
+    def on_run_failed(self, ctx: Any, exc: BaseException) -> None:
+        self.events.append(("failed", ctx, exc))
+
+    def on_run_rejected(self, ctx: Any, reason: str) -> None:
+        self.events.append(("rejected", ctx, reason))
+
+    @property
+    def names(self) -> list[str]:
+        return [event[0] for event in self.events]
+
+
+def _boom(state: ChatState) -> dict[str, Any]:
+    raise RuntimeError("platform boom")
+
+
+def _build_failing_graph(*, checkpointer: Any = None) -> Any:
+    builder = StateGraph(ChatState)
+    builder.add_node("boom", _boom)
+    builder.add_edge(START, "boom")
+    builder.add_edge("boom", END)
+    return builder.compile(checkpointer=checkpointer)
+
+
+class TestPlatformObserver:
+    """Platform run endpoints emit lifecycle events through the observer."""
+
+    def _create_thread(self, fa: func.FunctionApp) -> str:
+        create_fn = _get_fn(fa, "aflg_platform_threads_create")
+        resp = create_fn(_post("/api/threads", {}))
+        tid: str = json.loads(resp.get_body())["thread_id"]
+        return tid
+
+    def test_runs_wait_emits_started_then_completed(self) -> None:
+        obs = _RecordingObserver()
+        graph = _build_graph(checkpointer=MemorySaver())
+        store = InMemoryThreadStore(id_factory=lambda: "po-1")
+        app = _make_platform_app(graph, store=store, observer=obs)
+        fa = app.function_app
+        tid = self._create_thread(fa)
+
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+        resp = wait_fn(
+            _post(
+                f"/api/threads/{tid}/runs/wait",
+                {"assistant_id": "agent", "input": {"user_text": "Ob"}},
+                thread_id=tid,
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "completed"]
+        assert obs.events[0][1].endpoint == "invoke"
+
+    def test_runs_wait_emits_failed_on_graph_error(self) -> None:
+        obs = _RecordingObserver()
+        graph = _build_failing_graph(checkpointer=MemorySaver())
+        store = InMemoryThreadStore(id_factory=lambda: "po-2")
+        app = _make_platform_app(graph, store=store, observer=obs)
+        fa = app.function_app
+        tid = self._create_thread(fa)
+
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait")
+        resp = wait_fn(
+            _post(
+                f"/api/threads/{tid}/runs/wait",
+                {"assistant_id": "agent", "input": {"user_text": "Er"}},
+                thread_id=tid,
+            )
+        )
+        assert resp.status_code == 500
+        assert obs.names == ["started", "failed"]
+        assert isinstance(obs.events[1][2], BaseException)
+
+    def test_runs_stream_emits_started_then_completed(self) -> None:
+        obs = _RecordingObserver()
+        graph = _build_graph(checkpointer=MemorySaver())
+        store = InMemoryThreadStore(id_factory=lambda: "po-3")
+        app = _make_platform_app(graph, store=store, observer=obs)
+        fa = app.function_app
+        tid = self._create_thread(fa)
+
+        stream_fn = _get_fn(fa, "aflg_platform_runs_stream")
+        resp = stream_fn(
+            _post(
+                f"/api/threads/{tid}/runs/stream",
+                {
+                    "assistant_id": "agent",
+                    "input": {"user_text": "St"},
+                    "stream_mode": "values",
+                },
+                thread_id=tid,
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "completed"]
+        assert obs.events[0][1].endpoint == "stream"
+        assert obs.events[0][1].stream_mode == "values"
+
+    def test_runs_wait_threadless_emits_started_then_completed(self) -> None:
+        obs = _RecordingObserver()
+        graph = _build_graph()
+        app = _make_platform_app(graph, observer=obs)
+        fa = app.function_app
+
+        wait_fn = _get_fn(fa, "aflg_platform_runs_wait_threadless")
+        resp = wait_fn(
+            _post(
+                "/api/runs/wait",
+                {"assistant_id": "agent", "input": {"user_text": "Tl"}},
+            )
+        )
+        assert resp.status_code == 200
+        assert obs.names == ["started", "completed"]
+        assert obs.events[0][1].has_checkpointer is False

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -48,6 +48,8 @@ def test_all_exports() -> None:
     assert "RunContext" in azure_functions_langgraph.__all__
     assert "NoOpRunObserver" in azure_functions_langgraph.__all__
     assert "RunRejectedReason" in azure_functions_langgraph.__all__
+    assert "LoggingRunObserver" in azure_functions_langgraph.__all__
+    assert "RunTransport" in azure_functions_langgraph.__all__
 
 
 def test_contracts_importable() -> None:
@@ -158,6 +160,7 @@ def test_azure_table_thread_store_from_table_client_factory() -> None:
 
 def test_observability_importable_from_package() -> None:
     from azure_functions_langgraph import (
+        LoggingRunObserver,
         NoOpRunObserver,
         RunContext,
         RunObserver,
@@ -168,5 +171,8 @@ def test_observability_importable_from_package() -> None:
     assert RunContext is not None
     assert NoOpRunObserver is not None
     assert RunRejectedReason is not None
+    assert LoggingRunObserver is not None
+    # LoggingRunObserver satisfies the RunObserver protocol.
+    assert isinstance(LoggingRunObserver(), RunObserver)
     # NoOpRunObserver satisfies the RunObserver protocol.
     assert isinstance(NoOpRunObserver(), RunObserver)


### PR DESCRIPTION
## Summary

Implements #407 — enriches the run-lifecycle observability contract (shipped in #425) with safe telemetry fields and ships a dependency-free built-in `LoggingRunObserver`, so operators get run telemetry with zero boilerplate.

- **`RunContext`**: append defaulted, non-sensitive correlation fields — `assistant_id`, `invocation_id`, `stream_mode`, `transport`, `has_checkpointer`, `lock_backend`. `RunTransport` (`buffered`/`streaming`) is reserved so opt-in true streaming (#406) can adopt this contract without a breaking change. The API shape from #425 (4-method observer, no event objects) is preserved.
- **`LoggingRunObserver`**: a stdlib-`logging` observer emitting one structured record per lifecycle event under a single `extra` key (`langgraph_run`). Logs only correlation ids, timing, run metadata, a derived `status`, and (on failure) the exception `error_type` (class name only) — **never** input, output, config, headers, or secrets.
- **Wiring**: the new fields flow through all four native handlers; Platform `runs/wait` + `runs/stream` (threaded and threadless) now emit `started`/`completed`/`failed`/`rejected` parity via `PlatformRouteDeps(observer=...)`.
- **Exports**: `LoggingRunObserver` + `RunTransport` from the top-level package.
- **Example**: `examples/observability_app_insights/` — built-in observer wired for Application Insights, with copy-pasteable KQL queries (run count, latency percentiles, error rate, per-thread correlation). Wired into the examples smoke test.
- **Docs**: README "Run observability" section and an updated production-guide observability section.

## Boundary (per #407)

The package owns the **domain signal** only. It does not own log formatting, App Insights ingestion, OpenTelemetry exporters, tracer-provider setup, sampling policy, or PII redaction. Observer failures are isolated and can never fail a graph run. An OpenTelemetry observer is intentionally deferred to a follow-up issue.

## Testing

- New `TestObserverContextFields`, `TestLoggingRunObserver`, `TestObservabilityHelpers` (native) and `TestPlatformObserver` (platform parity) suites.
- Public-API export assertions for `LoggingRunObserver` + `RunTransport`.
- `hatch run lint` clean; full suite green; coverage **96.48%** (≥95% gate).

Closes #407.