### PR TITLE
fix(locks): tolerate leased-marker upload conflict in AzureBlobLeaseThreadLock

### DIFF
--- a/src/azure_functions_langgraph/locks/azure_blob.py
+++ b/src/azure_functions_langgraph/locks/azure_blob.py
@@ -342,6 +342,18 @@ class AzureBlobLeaseThreadLock:
             # Expected on every acquire after the first — the marker blob is
             # created once and reused for every subsequent lease attempt.
             return
+        except self._http_response_error as exc:
+            # The marker already exists AND is currently leased by another
+            # host. A conditional (``overwrite=False``) upload against a leased
+            # blob is rejected by Azure with a lease-conflict error (e.g. 412
+            # ``LeaseIdMissing`` / 409) rather than ``ResourceExistsError``.
+            # A leased blob provably already exists, so this is equivalent to
+            # the existing-marker case: swallow it and let the caller proceed
+            # to ``acquire_lease`` (which will report contention as ``None``).
+            # Any non-lease HTTP error (auth/RBAC/network) still propagates.
+            if self._is_lease_conflict(exc):
+                return
+            raise
 
     def acquire(self, graph_name: str, thread_id: str, timeout: float = 0.0) -> str | None:
         """Attempt to hold an Azure Blob lease for ``(graph_name, thread_id)``.

--- a/tests/test_locks_azure_blob.py
+++ b/tests/test_locks_azure_blob.py
@@ -71,6 +71,17 @@ class MockBlobClient:
 
     def upload_blob(self, data: bytes, overwrite: bool = False) -> None:
         if self._name in self._container.blobs:
+            # Faithful to Azure: a conditional (``overwrite=False``) upload
+            # against an existing blob that is currently leased by another
+            # holder is rejected with a lease conflict (412 ``LeaseIdMissing``),
+            # NOT ``ResourceExistsError``. This is the cross-host path that
+            # ``_ensure_marker`` must tolerate.
+            if self._active_lease is not None and not self._active_lease.released:
+                raise FakeHttpResponseError(
+                    "LeaseIdMissing",
+                    error_code="LeaseIdMissing",
+                    status_code=412,
+                )
             if not overwrite:
                 raise FakeResourceExistsError(self._name)
         self._container.blobs[self._name] = data
@@ -285,6 +296,44 @@ class TestAcquireRelease:
             assert challenger.acquire("graph", "t1", timeout=0.0) is None
         finally:
             holder.release("graph", "t1", holder_token)
+
+    def test_leased_marker_upload_conflict_does_not_raise(self) -> None:
+        """Regression (#333/#386): a challenger whose marker upload hits the
+        holder's lease must NOT crash — it must fall through to acquire_lease
+        and report contention as ``None`` (mapped to HTTP 409 by the handler).
+
+        Before the fix, ``_ensure_marker`` caught only ``ResourceExistsError``,
+        so the 412 ``LeaseIdMissing`` from uploading over a leased marker
+        propagated out of ``acquire()`` and surfaced as an empty-body 500.
+        """
+        container = MockContainerClient()
+        holder = _make_lock(container)
+        holder_token = holder.acquire("graph", "t1")
+        assert holder_token
+        try:
+            challenger = _make_lock(container)
+            # Must return None (contention) rather than raising.
+            assert challenger.acquire("graph", "t1") is None
+        finally:
+            holder.release("graph", "t1", holder_token)
+
+    def test_ensure_marker_propagates_non_lease_http_error(self) -> None:
+        """A non-lease HTTP error (e.g. 403 auth/RBAC) on marker upload must
+        still propagate — it is a genuine failure, not benign contention."""
+        container = MockContainerClient()
+        lock = _make_lock(container)
+        blob_client = container.get_blob_client("marker")
+
+        def _boom(data: bytes, overwrite: bool = False) -> None:
+            raise FakeHttpResponseError(
+                "AuthorizationFailure",
+                error_code="AuthorizationFailure",
+                status_code=403,
+            )
+
+        blob_client.upload_blob = _boom  # type: ignore[method-assign]
+        with pytest.raises(FakeHttpResponseError):
+            lock._ensure_marker(blob_client)
 
     def test_marker_reused_across_acquires(self) -> None:
         """Marker blob is created once, then reused (idempotent)."""


### PR DESCRIPTION
## Context
The real-Azure release certification (`e2e-azure.yml`) for v0.8.2 caught a genuine distributed-lock defect. In the two-app single-writer exclusivity e2e (`tests/e2e/test_langgraph_lock_e2e.py`, #386), App B returned an **empty-body HTTP 500** instead of the intended **409** under cross-host lease contention.

## Root cause
`AzureBlobLeaseThreadLock._ensure_marker` does a conditional `upload_blob(overwrite=False)` and caught **only** `ResourceExistsError`. When a second host uploads over a marker blob that already exists **and is currently leased by another host**, Azure rejects it with a lease-conflict error (412 `LeaseIdMissing` / 409) — an `HttpResponseError`, not `ResourceExistsError`. That propagated out of `acquire()` (invoked outside the native handler's `try` block in `_handlers.py`) and surfaced as a bare host-level 500.

Single-app/unit runs never leased the marker from *another* host, so CI stayed green — only the real-Azure two-app cert exposed it.

## Fix
- `_ensure_marker` now also treats a **lease conflict** on the marker upload as "marker already exists, proceed" (via the existing `_is_lease_conflict` helper), falling through to `acquire_lease`, which correctly reports contention as `None` → 409. Genuine non-lease HTTP errors (auth/RBAC/network) still propagate.
- The unit mock's `upload_blob` now faithfully raises a 412 lease conflict when the existing marker is leased, so `test_non_blocking_returns_false_on_conflict` genuinely reproduces the scenario; added explicit regression tests (`test_leased_marker_upload_conflict_does_not_raise`, `test_ensure_marker_propagates_non_lease_http_error`).

## Acceptance
- [x] Regression tests fail without the fix (reproduce the exact `LeaseIdMissing` crash), pass with it
- [x] `make lint` / `make typecheck` clean
- [x] Coverage 96.48% (≥95%)
- [ ] Real-Azure `e2e-azure.yml` re-cert green on the merge commit (gates the v0.8.2 publish)

## References
- Blocks release of v0.8.2 (#333 release-cert gate)
- Distributed lock e2e: #386