### PR TITLE
fix(ci): test matrix silently runs Python 3.10 due to hatch default-env pin

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,11 +10,57 @@ permissions:
   contents: read
 
 jobs:
+  # Lint, type-check and security run once on a single pinned interpreter
+  # (Python 3.10, matching the ruff/mypy target-version in pyproject). These
+  # checks are interpreter-agnostic, so fanning them across the matrix would
+  # only duplicate work. Installed with a plain `pip install -e '.[dev]'` so the
+  # checks run on the interpreter this job provisions (NOT through the
+  # Python-3.10-pinned hatch env, which is what silently forced the whole test
+  # matrix onto 3.10 before this fix).
+  quality:
+    name: Lint, type-check & security (Py 3.10)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Install package with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint workflows (pin hygiene + release-gate canonical SHAs)
+        run: |
+          python tools/lint_release_workflows.py
+          python tools/lint_workflow_pins.py
+
+      - name: Ruff style check
+        run: ruff check src tests
+
+      - name: Type check (mypy, strict)
+        run: mypy src tests
+
+      - name: Security scan (bandit)
+        run: python -m bandit -r src
+
   test:
+    name: Test (Py ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # The full test suite runs against the declared dependency contract
+        # (azure-functions>=1.17,<2.0.0). That 1.x line is only installable on
+        # Python 3.10-3.12 (recent 1.x releases pin requires-python <3.13), so
+        # the matrix stops at 3.12. Python 3.13/3.14 are exercised by the
+        # non-blocking `azure-functions-2x` wheel lane below (Py 3.13) - running
+        # the full suite there would require the (uncertified) 2.x worker path.
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout code
@@ -25,19 +71,44 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Hatch and dependencies via Makefile
+      - name: Assert the runtime interpreter matches the matrix cell
+        # Tests must run on the interpreter this cell claims to exercise. Before
+        # this fix the whole matrix ran through the Python-3.10-pinned hatch env,
+        # so 3.11/3.12 were never actually tested. This guard fails loudly if the
+        # running interpreter ever drifts from matrix.python-version again.
+        env:
+          EXPECTED: ${{ matrix.python-version }}
         run: |
-          pip install hatch
-          make install
+          python - <<'PY'
+          import os, sys
+          expected = tuple(int(p) for p in os.environ["EXPECTED"].split("."))
+          actual = sys.version_info[: len(expected)]
+          assert actual == expected, f"interpreter {actual} != matrix {expected}"
+          print(f"interpreter OK: {sys.version.split()[0]}")
+          PY
 
-      - name: Run full quality checks
-        # This matrix job (Python 3.10-3.14) is the coverage gate: `make
-        # check-all` -> `make test` -> pytest, which picks up the `--cov` +
-        # `fail_under = 95` settings from pyproject.toml and fails the build if
-        # coverage drops below 95% on any Python version.
-        run: make check-all
+      - name: Install package with dev extras (on the matrix interpreter)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests on the matrix interpreter
+        # Raw pytest on the interpreter provisioned above (NOT through the
+        # Python-3.10-pinned hatch env). The repo pytest config enables --cov
+        # with fail_under=95; enforce that gate on the canonical 3.10 cell and
+        # run the other cells with --no-cov so a version-variant cell cannot
+        # fail the build on a spurious coverage dip.
+        env:
+          IS_COVERAGE_CELL: ${{ matrix.python-version == '3.10' }}
+        run: |
+          if [ "$IS_COVERAGE_CELL" = "true" ]; then
+            pytest tests/
+          else
+            pytest tests/ --no-cov
+          fi
 
       - name: Verify coverage output
+        if: matrix.python-version == '3.10'
         run: ls -lh coverage.xml
 
       - name: Upload coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,14 +126,12 @@ precommit-install = "pre-commit install"
 security = "python -m bandit -r src"
 
 [tool.hatch.envs.cosmos]
-python = "3.10"
 features = ["dev", "cosmos"]
 
 [tool.hatch.envs.cosmos.scripts]
 test = "pytest -v -m integration tests/integration/ --no-cov"
 
 [tool.hatch.envs.table]
-python = "3.10"
 features = ["dev", "azure-table"]
 
 [tool.hatch.envs.table.scripts]


### PR DESCRIPTION
## Context

`.github/workflows/ci-test.yml` declared a Python `3.10`–`3.14` test
matrix, but every cell ran `make check-all`, which routes all work
through `hatch run …`. The default hatch env pins `python = "3.10"`, so
each matrix cell silently re-resolved to Python 3.10 — per-version
status/coverage claims were false. The repo-local `cosmos` and `table`
hatch envs carried the same 3.10 pin.

## What changed

- Added a `quality` job (Python 3.10) running the interpreter-agnostic
  checks — workflow lint, `ruff check`, `mypy`, `bandit` — installed with
  a plain `pip install -e ".[dev]"` (not through the 3.10-pinned hatch
  env).
- The `test` matrix now installs on the interpreter each cell provisions
  and runs **raw `pytest`** (not via hatch), preceded by an
  interpreter-assert guard that fails loudly if the running Python ever
  drifts from `matrix.python-version` again.
- Capped the full-suite matrix at **3.12**: the declared contract pins
  `azure-functions>=1.17,<2.0.0`, whose 1.x line is only installable on
  3.10–3.12. Python 3.13 remains covered by the existing, non-blocking
  `azure-functions-2x` wheel lane; the `langgraph-min` / `langgraph-sdk-max`
  / `langgraph-latest` compat lanes are unchanged.
- Coverage gate (`fail_under=95`) + Codecov upload stay on the 3.10 cell;
  other cells run with `--no-cov`.
- Dropped the `python = "3.10"` pin from the `cosmos` and `table` hatch
  envs so they honor the provisioning interpreter too (per the issue's
  repo-specific note). Both integration workflows already run raw pytest
  on 3.11, so this only removes the silent local-tooling pin.

## Acceptance Checklist

- [x] Matrix `test` cells run on the interpreter named by
      `matrix.python-version` (setup-python + `pip install -e '.[dev]'` +
      direct `pytest`).
- [x] Guard assertion fails if the runtime interpreter differs from
      `matrix.python-version`.
- [x] Lint / mypy / security / coverage-upload kept on a single pinned
      interpreter (the `quality` job + 3.10 cell).
- [x] 3.13 wheel lane preserved (`azure-functions-2x`, non-blocking).
- [x] `cosmos` / `table` hatch envs un-pinned.
- [x] Workflow linters pass; all actions SHA-pinned.

## References

- Fleet reference: openapi #554/#555, validation #379, logging #423.

Closes #427