### PR TITLE
feat(checkpointer): add native async blob I/O to AzureBlobCheckpointSaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,11 +498,12 @@ For a complete runnable example (Managed Identity in prod, Azurite + connection 
 
 #### Native async checkpoint I/O
 
-By default `AzureBlobCheckpointSaver` only implements synchronous checkpoint
-I/O. When a graph is driven through the async endpoints (`graph.ainvoke` /
-`graph.astream`), the saver's async methods (`aget_tuple`, `alist`, `aput`,
-`aput_writes`) fall back to running the synchronous implementation in a thread
-executor and emit a one-time warning — correct, but not truly non-blocking.
+By default `AzureBlobCheckpointSaver` is configured with a synchronous
+`ContainerClient`. Its async methods (`aget_tuple`, `alist`, `aput`,
+`aput_writes`, `adelete_thread`) remain fully available: when a graph is driven
+through the async endpoints (`graph.ainvoke` / `graph.astream`) without an aio
+client, they run the synchronous implementation in a thread executor and emit a
+one-time warning — correct, but not truly non-blocking.
 
 To get **native, non-blocking** blob I/O on the async path, pass an
 `azure.storage.blob.aio.ContainerClient` as `aio_container_client` alongside the

--- a/README.md
+++ b/README.md
@@ -496,6 +496,48 @@ Required role assignments on the storage account (or narrower scopes):
 
 For a complete runnable example (Managed Identity in prod, Azurite + connection string locally), see [`examples/managed_identity_storage/`](examples/managed_identity_storage/).
 
+#### Native async checkpoint I/O
+
+By default `AzureBlobCheckpointSaver` only implements synchronous checkpoint
+I/O. When a graph is driven through the async endpoints (`graph.ainvoke` /
+`graph.astream`), the saver's async methods (`aget_tuple`, `alist`, `aput`,
+`aput_writes`) fall back to running the synchronous implementation in a thread
+executor and emit a one-time warning — correct, but not truly non-blocking.
+
+To get **native, non-blocking** blob I/O on the async path, pass an
+`azure.storage.blob.aio.ContainerClient` as `aio_container_client` alongside the
+synchronous `container_client`. Both clients share the same container; the sync
+methods use the sync client and the async methods use the aio client, so
+checkpoints written by one path are readable by the other:
+
+```python
+from azure.identity import DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential as AioDefaultAzureCredential
+from azure.storage.blob import ContainerClient
+from azure.storage.blob.aio import ContainerClient as AioContainerClient
+
+container_client = ContainerClient(
+    account_url="https://<account>.blob.core.windows.net",
+    container_name="langgraph-checkpoints",
+    credential=DefaultAzureCredential(),
+)
+aio_container_client = AioContainerClient(
+    account_url="https://<account>.blob.core.windows.net",
+    container_name="langgraph-checkpoints",
+    credential=AioDefaultAzureCredential(),
+)
+
+checkpointer = AzureBlobCheckpointSaver(
+    container_client=container_client,
+    aio_container_client=aio_container_client,
+)
+```
+
+> The caller owns the lifecycle of both clients (open/close), exactly as with
+> the synchronous client. `aio_container_client` is fully optional and
+> backward-compatible — omitting it preserves the previous executor-fallback
+> behaviour.
+
 #### Checkpoint store security
 
 The checkpointer backends persist graph state using LangGraph's default

--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -1559,3 +1559,15 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
                     "task_path": quote(task_path, safe=""),
                 },
             )
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        """Asynchronously delete all blobs for a thread (native aio when available)."""
+        if self._aio_container_client is None:
+            self._warn_sync_fallback("adelete_thread")
+            await asyncio.to_thread(self.delete_thread, thread_id)
+            return
+
+        container = self._require_aio_container_client()
+        thread_prefix = self._thread_prefix(thread_id)
+        async for blob in container.list_blobs(name_starts_with=thread_prefix):
+            await container.get_blob_client(blob.name).delete_blob()

--- a/src/azure_functions_langgraph/checkpointers/azure_blob.py
+++ b/src/azure_functions_langgraph/checkpointers/azure_blob.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+import asyncio
+from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import importlib
@@ -100,6 +101,28 @@ class _ContainerClientProtocol(Protocol):
     def list_blobs(self, name_starts_with: str = "") -> Sequence[_BlobItemProtocol]: ...
 
 
+class _AsyncBlobDownloadProtocol(Protocol):
+    async def readall(self) -> bytes: ...
+
+
+class _AsyncBlobClientProtocol(Protocol):
+    async def upload_blob(
+        self, data: bytes, metadata: dict[str, str], overwrite: bool
+    ) -> None: ...
+
+    async def download_blob(self) -> _AsyncBlobDownloadProtocol: ...
+
+    async def get_blob_properties(self) -> _BlobPropertiesProtocol: ...
+
+    async def delete_blob(self) -> None: ...
+
+
+class _AsyncContainerClientProtocol(Protocol):
+    def get_blob_client(self, blob: str) -> _AsyncBlobClientProtocol: ...
+
+    def list_blobs(self, name_starts_with: str = "") -> AsyncIterator[_BlobItemProtocol]: ...
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -117,9 +140,26 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
         self,
         *,
         container_client: _ContainerClientProtocol,
+        aio_container_client: _AsyncContainerClientProtocol | None = None,
         serde: SerializerProtocol | None = None,
     ) -> None:
-        """Create a saver bound to an Azure Blob container client."""
+        """Create a saver bound to an Azure Blob container client.
+
+        Parameters
+        ----------
+        container_client:
+            Synchronous ``azure.storage.blob.ContainerClient`` used by every
+            synchronous method.
+        aio_container_client:
+            Optional asynchronous ``azure.storage.blob.aio.ContainerClient``.
+            When provided, the async methods (:meth:`aget_tuple`,
+            :meth:`alist`, :meth:`aput`, :meth:`aput_writes`) perform native
+            non-blocking blob I/O through it. When omitted, those methods fall
+            back to running the synchronous implementation in a thread executor
+            and emit a one-time warning.
+        serde:
+            Optional serializer protocol; defaults to LangGraph's serializer.
+        """
         try:
             azure_blob_module = importlib.import_module("azure.storage.blob")
         except ImportError as exc:
@@ -157,6 +197,32 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
             type[BaseException],
             resource_not_found_error,
         )
+
+        if aio_container_client is not None:
+            try:
+                azure_blob_aio_module = importlib.import_module("azure.storage.blob.aio")
+            except ImportError as exc:
+                raise ImportError(
+                    "AzureBlobCheckpointSaver async support requires optional "
+                    "dependency 'azure-storage-blob'. Install with: "
+                    "pip install azure-functions-langgraph[azure-blob]"
+                ) from exc
+            azure_aio_container_client = getattr(
+                azure_blob_aio_module, "ContainerClient", None
+            )
+            if azure_aio_container_client is None or not isinstance(
+                aio_container_client, azure_aio_container_client
+            ):
+                raise TypeError(
+                    "aio_container_client must be an instance of "
+                    "azure.storage.blob.aio.ContainerClient"
+                )
+        self._aio_container_client: _AsyncContainerClientProtocol | None = (
+            cast(_AsyncContainerClientProtocol, aio_container_client)
+            if aio_container_client is not None
+            else None
+        )
+        self._sync_fallback_warned = False
 
     def get_next_version(self, current: str | None, channel: None) -> str:
         """Return the next monotonic channel version string."""
@@ -996,3 +1062,500 @@ class AzureBlobCheckpointSaver(BaseCheckpointSaver[str]):
 
     def _escape(self, segment: str) -> str:
         return quote(segment, safe="")
+
+    # ------------------------------------------------------------------
+    # Native async API
+    #
+    # These mirror the synchronous methods above but perform blob I/O
+    # through ``aio_container_client`` (``azure.storage.blob.aio``). When no
+    # aio client was provided the public methods fall back to running the
+    # synchronous implementation in a thread executor (with a one-time
+    # warning) so a graph driven by ``ainvoke``/``astream`` still works.
+    # ------------------------------------------------------------------
+    def _require_aio_container_client(self) -> _AsyncContainerClientProtocol:
+        client = self._aio_container_client
+        if client is None:  # pragma: no cover - guarded by public methods
+            raise RuntimeError("aio_container_client is not configured")
+        return client
+
+    def _warn_sync_fallback(self, method: str) -> None:
+        if not self._sync_fallback_warned:
+            self._sync_fallback_warned = True
+            logger.warning(
+                "AzureBlobCheckpointSaver.%s was called without an "
+                "'aio_container_client'; falling back to running the "
+                "synchronous implementation in a thread executor. Pass "
+                "'aio_container_client' for native async blob I/O.",
+                method,
+            )
+
+    async def _adownload_blob(self, blob_path: str) -> bytes | None:
+        client = self._require_aio_container_client().get_blob_client(blob_path)
+        try:
+            downloader = await client.download_blob()
+            return await downloader.readall()
+        except self._not_found_error:
+            return None
+
+    async def _ablob_metadata(self, blob_path: str) -> dict[str, str]:
+        client = self._require_aio_container_client().get_blob_client(blob_path)
+        try:
+            properties = await client.get_blob_properties()
+        except self._not_found_error:
+            return {}
+        metadata = properties.metadata
+        return metadata if metadata is not None else {}
+
+    async def _adownload_typed_blob(
+        self, blob_path: str
+    ) -> tuple[str, bytes, dict[str, str]] | None:
+        """Async twin of :meth:`_download_typed_blob`."""
+        payload = await self._adownload_blob(blob_path)
+        if payload is None:
+            return None
+
+        metadata = await self._ablob_metadata(blob_path)
+        serde_type = metadata.get("serde_type")
+        if not serde_type:
+            logger.warning("Blob missing serde_type metadata: %s", blob_path)
+            return None
+
+        return (serde_type, payload, metadata)
+
+    async def _ablob_exists(self, blob_path: str) -> bool:
+        client = self._require_aio_container_client().get_blob_client(blob_path)
+        try:
+            await client.get_blob_properties()
+        except self._not_found_error:
+            return False
+        return True
+
+    async def _aupload_blob(
+        self, blob_path: str, payload: bytes, metadata: dict[str, str]
+    ) -> None:
+        client = self._require_aio_container_client().get_blob_client(blob_path)
+        await client.upload_blob(payload, metadata=metadata, overwrite=True)
+
+    async def _alist_blob_items(self, prefix: str) -> List[_BlobItemProtocol]:
+        container = self._require_aio_container_client()
+        items: List[_BlobItemProtocol] = []
+        async for blob in container.list_blobs(name_starts_with=prefix):
+            items.append(blob)
+        return items
+
+    async def _aread_latest_checkpoint_id(
+        self, thread_id: str, checkpoint_ns: str
+    ) -> str | None:
+        latest_path = self._latest_blob_path(thread_id, checkpoint_ns)
+        latest_payload = await self._adownload_blob(latest_path)
+        if latest_payload is None:
+            return None
+
+        try:
+            data = json.loads(latest_payload.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            logger.warning("Ignoring malformed latest.json at %s", latest_path)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        checkpoint_id = data.get("checkpoint_id")
+        if isinstance(checkpoint_id, str):
+            return checkpoint_id
+        return None
+
+    async def _afind_latest_checkpoint_id(
+        self, thread_id: str, checkpoint_ns: str
+    ) -> str | None:
+        checkpoint_ids = await self._alist_checkpoint_ids(thread_id, checkpoint_ns)
+        if not checkpoint_ids:
+            return None
+        return checkpoint_ids[0]
+
+    async def _alist_checkpoint_ids(
+        self, thread_id: str, checkpoint_ns: str
+    ) -> List[str]:
+        checkpoints_prefix = self._checkpoints_prefix(thread_id, checkpoint_ns)
+        checkpoint_ids: set[str] = set()
+
+        for blob in await self._alist_blob_items(checkpoints_prefix):
+            if not blob.name.endswith("/checkpoint.bin"):
+                continue
+
+            path_parts = blob.name.split("/")
+            if len(path_parts) != 7:
+                continue
+
+            checkpoint_ids.add(unquote(path_parts[5]))
+
+        return sorted(checkpoint_ids, reverse=True)
+
+    async def _alist_thread_ids(self) -> List[str]:
+        thread_ids: set[str] = set()
+        for blob in await self._alist_blob_items("threads/"):
+            path_parts = blob.name.split("/")
+            if len(path_parts) >= 2 and path_parts[0] == "threads":
+                thread_ids.add(unquote(path_parts[1]))
+        return sorted(thread_ids)
+
+    async def _alist_checkpoint_namespaces(self, thread_id: str) -> List[str]:
+        namespace_prefix = f"{self._thread_prefix(thread_id)}ns/"
+        checkpoint_namespaces: set[str] = set()
+
+        for blob in await self._alist_blob_items(namespace_prefix):
+            path_parts = blob.name.split("/")
+            if len(path_parts) >= 4 and path_parts[2] == "ns":
+                checkpoint_namespaces.add(unquote(path_parts[3]))
+
+        return sorted(checkpoint_namespaces)
+
+    async def _aload_channel_values(
+        self,
+        *,
+        thread_id: str,
+        checkpoint_ns: str,
+        channel_versions: ChannelVersions,
+    ) -> dict[str, Any]:
+        values: dict[str, Any] = {}
+        for channel, version in channel_versions.items():
+            typed_blob = await self._adownload_typed_blob(
+                self._value_blob_path(thread_id, checkpoint_ns, channel, version)
+            )
+            if typed_blob is None:
+                continue
+            if typed_blob[0] == "empty":
+                continue
+            values[channel] = self.serde.loads_typed((typed_blob[0], typed_blob[1]))
+        return values
+
+    async def _aload_pending_writes(
+        self, thread_id: str, checkpoint_ns: str, checkpoint_id: str
+    ) -> List[tuple[str, str, Any]]:
+        writes_prefix = self._writes_prefix(thread_id, checkpoint_ns, checkpoint_id)
+        loaded: List[tuple[str, int, str, Any]] = []
+
+        for blob in await self._alist_blob_items(writes_prefix):
+            if not blob.name.startswith(writes_prefix):
+                continue
+            relative = blob.name[len(writes_prefix) :]
+            rel_parts = relative.split("/")
+            if len(rel_parts) != 2:
+                continue
+
+            task_id = unquote(rel_parts[0])
+            file_name = rel_parts[1]
+            if not file_name.endswith(".bin"):
+                continue
+
+            try:
+                write_index = int(unquote(file_name.removesuffix(".bin")))
+            except ValueError:
+                continue
+            typed_blob_result = await self._adownload_typed_blob(blob.name)
+            if typed_blob_result is None:
+                continue
+
+            blob_meta = typed_blob_result[2]
+            raw_channel = blob_meta.get("channel")
+            raw_metadata_task_id = blob_meta.get("task_id")
+            if raw_channel is None:
+                continue
+            channel = unquote(raw_channel)
+            resolved_task_id = (
+                unquote(raw_metadata_task_id) if raw_metadata_task_id else task_id
+            )
+
+            value = self.serde.loads_typed((typed_blob_result[0], typed_blob_result[1]))
+            loaded.append((resolved_task_id, write_index, channel, value))
+
+        loaded.sort(key=lambda item: (item[0], item[1]))
+        return [(task_id, channel, value) for task_id, _idx, channel, value in loaded]
+
+    async def _abuild_tuple(
+        self,
+        *,
+        thread_id: str,
+        checkpoint_ns: str,
+        checkpoint_id: str,
+        return_config: RunnableConfig,
+    ) -> CheckpointTuple | None:
+        checkpoint_blob_path = self._checkpoint_blob_path(
+            thread_id, checkpoint_ns, checkpoint_id
+        )
+        checkpoint_blob_result = await self._adownload_typed_blob(checkpoint_blob_path)
+        if checkpoint_blob_result is None:
+            return None
+
+        serde_type, payload, checkpoint_blob_metadata = checkpoint_blob_result
+        raw_parent_id = checkpoint_blob_metadata.get("parent_id")
+        parent_checkpoint_id = unquote(raw_parent_id) if raw_parent_id else None
+        checkpoint_data: Checkpoint = self.serde.loads_typed((serde_type, payload))
+        channel_values = await self._aload_channel_values(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            channel_versions=checkpoint_data["channel_versions"],
+        )
+
+        metadata_blob_result = await self._adownload_typed_blob(
+            self._metadata_blob_path(thread_id, checkpoint_ns, checkpoint_id)
+        )
+        if metadata_blob_result is None:
+            return None
+        checkpoint_metadata: CheckpointMetadata = self.serde.loads_typed(
+            (metadata_blob_result[0], metadata_blob_result[1])
+        )
+
+        return CheckpointTuple(
+            config=return_config,
+            checkpoint={**checkpoint_data, "channel_values": channel_values},
+            metadata=checkpoint_metadata,
+            parent_config=(
+                self._checkpoint_config(thread_id, checkpoint_ns, parent_checkpoint_id)
+                if parent_checkpoint_id
+                else None
+            ),
+            pending_writes=await self._aload_pending_writes(
+                thread_id, checkpoint_ns, checkpoint_id
+            ),
+        )
+
+    async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        """Asynchronously fetch a checkpoint tuple (native aio when available)."""
+        if self._aio_container_client is None:
+            self._warn_sync_fallback("aget_tuple")
+            return await asyncio.to_thread(self.get_tuple, config)
+
+        thread_id = self._config_thread_id(config)
+        checkpoint_ns = self._config_checkpoint_ns(config)
+        requested_checkpoint_id = get_checkpoint_id(config)
+
+        if requested_checkpoint_id:
+            return await self._abuild_tuple(
+                thread_id=thread_id,
+                checkpoint_ns=checkpoint_ns,
+                checkpoint_id=requested_checkpoint_id,
+                return_config=config,
+            )
+
+        latest_hint = await self._aread_latest_checkpoint_id(thread_id, checkpoint_ns)
+        if latest_hint is not None:
+            hint_tuple = await self._abuild_tuple(
+                thread_id=thread_id,
+                checkpoint_ns=checkpoint_ns,
+                checkpoint_id=latest_hint,
+                return_config=self._checkpoint_config(
+                    thread_id, checkpoint_ns, latest_hint
+                ),
+            )
+            if hint_tuple is not None:
+                return hint_tuple
+
+        actual_latest = await self._afind_latest_checkpoint_id(thread_id, checkpoint_ns)
+        if actual_latest is None:
+            return None
+
+        return await self._abuild_tuple(
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            checkpoint_id=actual_latest,
+            return_config=self._checkpoint_config(
+                thread_id, checkpoint_ns, actual_latest
+            ),
+        )
+
+    async def alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        """Asynchronously list checkpoints (native aio when available)."""
+        if self._aio_container_client is None:
+            self._warn_sync_fallback("alist")
+            items = await asyncio.to_thread(
+                lambda: list(
+                    self.list(config, filter=filter, before=before, limit=limit)
+                )
+            )
+            for item in items:
+                yield item
+            return
+
+        remaining = limit
+        config_checkpoint_ns = self._config_checkpoint_ns(config) if config else None
+        config_checkpoint_id = get_checkpoint_id(config) if config else None
+        before_checkpoint_id = get_checkpoint_id(before) if before else None
+
+        thread_ids = (
+            [self._config_thread_id(config)]
+            if config
+            else await self._alist_thread_ids()
+        )
+        for thread_id in thread_ids:
+            checkpoint_namespaces = (
+                [config_checkpoint_ns]
+                if config_checkpoint_ns is not None
+                else await self._alist_checkpoint_namespaces(thread_id)
+            )
+            for checkpoint_ns in checkpoint_namespaces:
+                checkpoint_ids = await self._alist_checkpoint_ids(
+                    thread_id, checkpoint_ns
+                )
+                for checkpoint_id in checkpoint_ids:
+                    if (
+                        config_checkpoint_id is not None
+                        and checkpoint_id != config_checkpoint_id
+                    ):
+                        continue
+                    if (
+                        before_checkpoint_id is not None
+                        and checkpoint_id >= before_checkpoint_id
+                    ):
+                        continue
+
+                    checkpoint_tuple = await self._abuild_tuple(
+                        thread_id=thread_id,
+                        checkpoint_ns=checkpoint_ns,
+                        checkpoint_id=checkpoint_id,
+                        return_config=self._checkpoint_config(
+                            thread_id,
+                            checkpoint_ns,
+                            checkpoint_id,
+                        ),
+                    )
+                    if checkpoint_tuple is None:
+                        continue
+
+                    if filter and not all(
+                        query_value == checkpoint_tuple.metadata.get(query_key)
+                        for query_key, query_value in filter.items()
+                    ):
+                        continue
+
+                    if remaining is not None:
+                        if remaining <= 0:
+                            return
+                        remaining -= 1
+
+                    yield checkpoint_tuple
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Asynchronously store a checkpoint (native aio when available)."""
+        if self._aio_container_client is None:
+            self._warn_sync_fallback("aput")
+            return await asyncio.to_thread(
+                self.put, config, checkpoint, metadata, new_versions
+            )
+
+        thread_id = self._config_thread_id(config)
+        checkpoint_ns = self._config_checkpoint_ns(config)
+        checkpoint_id = checkpoint["id"]
+        parent_checkpoint_id = get_checkpoint_id(config)
+
+        checkpoint_data: dict[str, Any] = dict(checkpoint)
+        channel_values: dict[str, Any] = checkpoint_data.pop("channel_values", {})
+
+        # 1. Channel value blobs
+        for channel, version in new_versions.items():
+            value_blob_path = self._value_blob_path(
+                thread_id, checkpoint_ns, channel, version
+            )
+            if channel in channel_values:
+                serde_type, payload = self.serde.dumps_typed(channel_values[channel])
+            else:
+                serde_type, payload = "empty", b""
+            await self._aupload_blob(value_blob_path, payload, {"serde_type": serde_type})
+
+        # 2. Metadata blob (before commit marker)
+        metadata_payload_type, metadata_payload = self.serde.dumps_typed(
+            get_checkpoint_metadata(config, metadata)
+        )
+        await self._aupload_blob(
+            self._metadata_blob_path(thread_id, checkpoint_ns, checkpoint_id),
+            metadata_payload,
+            {"serde_type": metadata_payload_type},
+        )
+
+        # 3. Checkpoint blob (commit marker — existence = valid checkpoint)
+        checkpoint_serde_type, checkpoint_payload = self.serde.dumps_typed(
+            checkpoint_data
+        )
+        checkpoint_blob_metadata: dict[str, str] = {"serde_type": checkpoint_serde_type}
+        if parent_checkpoint_id is not None:
+            checkpoint_blob_metadata["parent_id"] = quote(parent_checkpoint_id, safe="")
+        await self._aupload_blob(
+            self._checkpoint_blob_path(thread_id, checkpoint_ns, checkpoint_id),
+            checkpoint_payload,
+            checkpoint_blob_metadata,
+        )
+
+        # 4. Monotonic latest.json hint (best-effort, after commit marker)
+        current_latest = await self._aread_latest_checkpoint_id(
+            thread_id, checkpoint_ns
+        )
+        if current_latest is None or checkpoint_id >= current_latest:
+            latest_payload = json.dumps(
+                {"checkpoint_id": checkpoint_id},
+                separators=(",", ":"),
+            ).encode()
+            await self._aupload_blob(
+                self._latest_blob_path(thread_id, checkpoint_ns),
+                latest_payload,
+                {},
+            )
+        return self._checkpoint_config(thread_id, checkpoint_ns, checkpoint_id)
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Asynchronously store task writes (native aio when available)."""
+        if self._aio_container_client is None:
+            self._warn_sync_fallback("aput_writes")
+            await asyncio.to_thread(
+                self.put_writes, config, writes, task_id, task_path
+            )
+            return
+
+        thread_id = self._config_thread_id(config)
+        checkpoint_ns = self._config_checkpoint_ns(config)
+        checkpoint_id = get_checkpoint_id(config)
+        if checkpoint_id is None:
+            raise ValueError("checkpoint_id is required in config to store writes")
+
+        for index, (channel, value) in enumerate(writes):
+            write_index = WRITES_IDX_MAP.get(channel, index)
+            write_blob_path = self._write_blob_path(
+                thread_id,
+                checkpoint_ns,
+                checkpoint_id,
+                task_id,
+                write_index,
+            )
+
+            if write_index >= 0 and await self._ablob_exists(write_blob_path):
+                continue
+
+            serde_type, payload = self.serde.dumps_typed(value)
+            await self._aupload_blob(
+                write_blob_path,
+                payload,
+                {
+                    "serde_type": serde_type,
+                    "channel": quote(channel, safe=""),
+                    "task_id": quote(task_id, safe=""),
+                    "task_path": quote(task_path, safe=""),
+                },
+            )

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -1874,3 +1874,40 @@ async def test_aget_tuple_ignores_malformed_latest(
     result = await saver.aget_tuple(_config(thread_id="t-bad"))
     assert result is not None
     assert result.checkpoint["id"] == "cp-1"
+
+
+async def test_adelete_thread_native(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, container = async_saver_and_container
+    await saver.aput(
+        _config(thread_id="t-del"),
+        _checkpoint("cp-1", channel_versions={"m": "v1"}, channel_values={"m": [1]}),
+        _metadata(),
+        {"m": "v1"},
+    )
+    assert any("t-del" in name for name in container.blobs)
+    await saver.adelete_thread("t-del")
+    assert not any("t-del" in name for name in container.blobs)
+    assert await saver.aget_tuple(_config(thread_id="t-del")) is None
+
+
+async def test_adelete_thread_fallback_warns_once(
+    fallback_saver_and_container: tuple[Any, MockContainerClient],
+    caplog: Any,
+) -> None:
+    saver, container = fallback_saver_and_container
+    await saver.aput(
+        _config(thread_id="t-del-fb"),
+        _checkpoint("cp-1", channel_versions={"m": "v1"}, channel_values={"m": [1]}),
+        _metadata(),
+        {"m": "v1"},
+    )
+    assert any("t-del-fb" in name for name in container.blobs)
+    with caplog.at_level("WARNING"):
+        await saver.adelete_thread("t-del-fb")
+    assert not any("t-del-fb" in name for name in container.blobs)
+    warnings = [
+        r for r in caplog.records if "aio_container_client" in r.getMessage()
+    ]
+    assert len(warnings) == 1

--- a/tests/test_checkpointers_azure_blob.py
+++ b/tests/test_checkpointers_azure_blob.py
@@ -159,11 +159,91 @@ class MockContainerClient:
         ]
 
 
+class _AsyncMockDownloadStream:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def readall(self) -> bytes:
+        return self._data
+
+
+class AsyncMockBlobClient:
+    def __init__(self, container: MockContainerClient, blob_name: str) -> None:
+        self._container = container
+        self._blob_name = blob_name
+
+    async def upload_blob(
+        self, data: bytes, metadata: dict[str, str], overwrite: bool
+    ) -> None:
+        if not overwrite and self._blob_name in self._container.blobs:
+            raise ValueError("Blob already exists")
+        existing = self._container.blobs.get(self._blob_name)
+        last_modified = (
+            existing.last_modified if existing is not None else _DEFAULT_BLOB_LAST_MODIFIED
+        )
+        self._container.blobs[self._blob_name] = _BlobRecord(
+            data=data, metadata=dict(metadata), last_modified=last_modified
+        )
+
+    async def download_blob(self) -> _AsyncMockDownloadStream:
+        record = self._container.blobs.get(self._blob_name)
+        if record is None:
+            raise FakeResourceNotFoundError(self._blob_name)
+        return _AsyncMockDownloadStream(record.data)
+
+    async def get_blob_properties(self) -> _MockBlobProperties:
+        record = self._container.blobs.get(self._blob_name)
+        if record is None:
+            raise FakeResourceNotFoundError(self._blob_name)
+        return _MockBlobProperties(metadata=dict(record.metadata))
+
+    async def delete_blob(self) -> None:
+        if self._blob_name not in self._container.blobs:
+            raise FakeResourceNotFoundError(self._blob_name)
+        del self._container.blobs[self._blob_name]
+
+
+class _AsyncBlobItemPaged:
+    def __init__(self, items: list[_BlobItem]) -> None:
+        self._items = items
+
+    async def __aiter__(self) -> Any:
+        for item in self._items:
+            yield item
+
+
+class AsyncMockContainerClient:
+    """Async mock backed by a (possibly shared) :class:`MockContainerClient`."""
+
+    def __init__(self, backing: MockContainerClient | None = None) -> None:
+        self._backing = backing if backing is not None else MockContainerClient()
+
+    @property
+    def blobs(self) -> dict[str, _BlobRecord]:
+        return self._backing.blobs
+
+    def get_blob_client(self, blob: str) -> AsyncMockBlobClient:
+        return AsyncMockBlobClient(self._backing, blob)
+
+    def list_blobs(self, name_starts_with: str = "") -> _AsyncBlobItemPaged:
+        return _AsyncBlobItemPaged(
+            [
+                _BlobItem(name=name, last_modified=record.last_modified)
+                for name, record in sorted(self._backing.blobs.items())
+                if name.startswith(name_starts_with)
+            ]
+        )
+
+
 @pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 def _install_fake_azure_modules(monkeypatch: Any) -> None:
     azure_mod = types.ModuleType("azure")
     azure_storage_mod = types.ModuleType("azure.storage")
     azure_blob_mod = types.ModuleType("azure.storage.blob")
+    setattr(azure_blob_mod, "ContainerClient", MockContainerClient)
+    azure_blob_aio_mod = types.ModuleType("azure.storage.blob.aio")
+    setattr(azure_blob_aio_mod, "ContainerClient", AsyncMockContainerClient)
+    setattr(azure_blob_mod, "aio", azure_blob_aio_mod)
     setattr(azure_blob_mod, "ContainerClient", MockContainerClient)
 
     azure_core_mod = types.ModuleType("azure.core")
@@ -173,6 +253,7 @@ def _install_fake_azure_modules(monkeypatch: Any) -> None:
     monkeypatch.setitem(sys.modules, "azure", azure_mod)
     monkeypatch.setitem(sys.modules, "azure.storage", azure_storage_mod)
     monkeypatch.setitem(sys.modules, "azure.storage.blob", azure_blob_mod)
+    monkeypatch.setitem(sys.modules, "azure.storage.blob.aio", azure_blob_aio_mod)
     monkeypatch.setitem(sys.modules, "azure.core", azure_core_mod)
     monkeypatch.setitem(sys.modules, "azure.core.exceptions", azure_core_exceptions_mod)
 
@@ -183,6 +264,28 @@ def saver_and_container() -> tuple[_CheckpointSaverProtocol, MockContainerClient
     module = importlib.import_module("azure_functions_langgraph.checkpointers.azure_blob")
     saver_cls = getattr(module, "AzureBlobCheckpointSaver")
     saver = cast(_CheckpointSaverProtocol, saver_cls(container_client=container))
+    return saver, container
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+def async_saver_and_container() -> tuple[Any, MockContainerClient]:
+    """Saver wired with both sync and aio clients over one shared store."""
+    container = MockContainerClient()
+    aio_container = AsyncMockContainerClient(backing=container)
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.azure_blob")
+    saver_cls = getattr(module, "AzureBlobCheckpointSaver")
+    saver = saver_cls(container_client=container, aio_container_client=aio_container)
+    return saver, container
+
+
+@pytest.fixture  # type: ignore[untyped-decorator]
+def fallback_saver_and_container() -> tuple[Any, MockContainerClient]:
+    """Saver with no aio client — async methods use the executor fallback."""
+    container = MockContainerClient()
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.azure_blob")
+    saver_cls = getattr(module, "AzureBlobCheckpointSaver")
+    saver = saver_cls(container_client=container)
+    return saver, container
     return saver, container
 
 
@@ -1460,3 +1563,314 @@ async def test_conformance_base_capabilities() -> None:
         assert result.passed, (
             f"base capability {cap!r} failed conformance: {result.failures!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Native async API tests
+# ---------------------------------------------------------------------------
+async def _collect(aiter: Any) -> list[Any]:
+    items = []
+    async for item in aiter:
+        items.append(item)
+    return items
+
+
+def test_aio_container_client_type_error() -> None:
+    module = importlib.import_module("azure_functions_langgraph.checkpointers.azure_blob")
+    saver_cls = getattr(module, "AzureBlobCheckpointSaver")
+    with pytest.raises(TypeError, match="aio_container_client"):
+        saver_cls(
+            container_client=MockContainerClient(),
+            aio_container_client=object(),
+        )
+
+
+async def test_aput_and_aget_tuple_native(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    cfg = _config(thread_id="t-async", checkpoint_ns="")
+    checkpoint = _checkpoint(
+        "cp-001",
+        channel_values={"messages": ["hi"]},
+        channel_versions={"messages": "v1"},
+    )
+    saved_config = await saver.aput(cfg, checkpoint, _metadata(), {"messages": "v1"})
+    result = await saver.aget_tuple(saved_config)
+
+    assert result is not None
+    assert result.config == saved_config
+    assert result.checkpoint["id"] == "cp-001"
+    assert result.checkpoint["channel_values"] == {"messages": ["hi"]}
+    assert result.metadata["run_id"] == "run-1"
+
+
+async def test_aget_tuple_missing_returns_none(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    assert await saver.aget_tuple(_config(thread_id="nope")) is None
+
+
+async def test_aget_tuple_by_explicit_checkpoint_id(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    cfg = _config(thread_id="t-id")
+    checkpoint = _checkpoint(
+        "cp-xyz",
+        channel_values={"messages": ["a"]},
+        channel_versions={"messages": "v1"},
+    )
+    await saver.aput(cfg, checkpoint, _metadata(), {"messages": "v1"})
+    by_id = _config(thread_id="t-id", checkpoint_id="cp-xyz")
+    result = await saver.aget_tuple(by_id)
+    assert result is not None
+    assert result.checkpoint["id"] == "cp-xyz"
+
+
+async def test_aget_tuple_stale_hint_falls_back_to_scan(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, container = async_saver_and_container
+    cfg = _config(thread_id="t-stale")
+    await saver.aput(
+        cfg,
+        _checkpoint("cp-1", channel_versions={"m": "v1"}, channel_values={"m": [1]}),
+        _metadata(step=1),
+        {"m": "v1"},
+    )
+    cfg2 = _config(thread_id="t-stale", checkpoint_id="cp-1")
+    await saver.aput(
+        cfg2,
+        _checkpoint("cp-2", channel_versions={"m": "v2"}, channel_values={"m": [2]}),
+        _metadata(step=2),
+        {"m": "v2"},
+    )
+    # Corrupt the latest hint target: delete cp-2's commit marker so the hint
+    # is stale and the scan must fall back to cp-1.
+    marker = [n for n in container.blobs if n.endswith("cp-2/checkpoint.bin")]
+    assert marker
+    del container.blobs[marker[0]]
+
+    result = await saver.aget_tuple(_config(thread_id="t-stale"))
+    assert result is not None
+    assert result.checkpoint["id"] == "cp-1"
+
+
+async def test_aput_writes_and_pending_writes(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    cfg = _config(thread_id="t-w")
+    await saver.aput(
+        cfg,
+        _checkpoint("cp-w", channel_versions={"m": "v1"}, channel_values={"m": [1]}),
+        _metadata(),
+        {"m": "v1"},
+    )
+    write_cfg = _config(thread_id="t-w", checkpoint_id="cp-w")
+    await saver.aput_writes(write_cfg, [("out", {"ok": True})], task_id="task-1")
+    # Idempotent no-op re-write on same index is skipped.
+    await saver.aput_writes(write_cfg, [("out", {"ok": True})], task_id="task-1")
+
+    result = await saver.aget_tuple(write_cfg)
+    assert result is not None
+    assert ("task-1", "out", {"ok": True}) in result.pending_writes
+
+
+async def test_aput_writes_requires_checkpoint_id(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    with pytest.raises(ValueError, match="checkpoint_id is required"):
+        await saver.aput_writes(_config(thread_id="t"), [("c", 1)], task_id="tk")
+
+
+async def test_aput_empty_channel_value(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    cfg = _config(thread_id="t-empty")
+    # new_versions references a channel absent from channel_values -> 'empty'.
+    await saver.aput(
+        cfg,
+        _checkpoint("cp-e", channel_versions={"m": "v1"}),
+        _metadata(),
+        {"m": "v1"},
+    )
+    result = await saver.aget_tuple(_config(thread_id="t-empty"))
+    assert result is not None
+    assert result.checkpoint["channel_values"] == {}
+
+
+async def test_alist_native_filter_before_limit(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    cfg = _config(thread_id="t-list")
+    prev = cfg
+    for i in range(1, 4):
+        prev = await saver.aput(
+            prev,
+            _checkpoint(
+                f"cp-{i:03d}",
+                channel_versions={"m": f"v{i}"},
+                channel_values={"m": [i]},
+            ),
+            _metadata(step=i),
+            {"m": f"v{i}"},
+        )
+
+    all_tuples = await _collect(saver.alist(_config(thread_id="t-list")))
+    assert [t.checkpoint["id"] for t in all_tuples] == ["cp-003", "cp-002", "cp-001"]
+
+    limited = await _collect(saver.alist(_config(thread_id="t-list"), limit=1))
+    assert [t.checkpoint["id"] for t in limited] == ["cp-003"]
+
+    before = await _collect(
+        saver.alist(
+            _config(thread_id="t-list"),
+            before=_config(thread_id="t-list", checkpoint_id="cp-003"),
+        )
+    )
+    assert [t.checkpoint["id"] for t in before] == ["cp-002", "cp-001"]
+
+    filtered = await _collect(
+        saver.alist(_config(thread_id="t-list"), filter={"step": 2})
+    )
+    assert [t.checkpoint["id"] for t in filtered] == ["cp-002"]
+
+
+async def test_alist_no_config_scans_all_threads(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    for thread in ("a", "b"):
+        await saver.aput(
+            _config(thread_id=thread),
+            _checkpoint("cp-1", channel_versions={"m": "v1"}, channel_values={"m": [1]}),
+            _metadata(),
+            {"m": "v1"},
+        )
+    tuples = await _collect(saver.alist(None))
+    threads = {t.config["configurable"]["thread_id"] for t in tuples}
+    assert threads == {"a", "b"}
+
+
+async def test_cross_compat_sync_write_async_read(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    cfg = _config(thread_id="t-x1")
+    checkpoint = _checkpoint(
+        "cp-sync",
+        channel_values={"messages": ["written-sync"]},
+        channel_versions={"messages": "v1"},
+    )
+    saved = saver.put(cfg, checkpoint, _metadata(), {"messages": "v1"})
+    saver.put_writes(
+        _config(thread_id="t-x1", checkpoint_id="cp-sync"),
+        [("out", {"n": 1})],
+        task_id="tk",
+    )
+
+    result = await saver.aget_tuple(saved)
+    assert result is not None
+    assert result.checkpoint["channel_values"] == {"messages": ["written-sync"]}
+    assert ("tk", "out", {"n": 1}) in result.pending_writes
+
+
+async def test_cross_compat_async_write_sync_read(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    cfg = _config(thread_id="t-x2")
+    checkpoint = _checkpoint(
+        "cp-async",
+        channel_values={"messages": ["written-async"]},
+        channel_versions={"messages": "v1"},
+    )
+    saved = await saver.aput(cfg, checkpoint, _metadata(), {"messages": "v1"})
+    await saver.aput_writes(
+        _config(thread_id="t-x2", checkpoint_id="cp-async"),
+        [("out", {"n": 2})],
+        task_id="tk",
+    )
+
+    result = saver.get_tuple(saved)
+    assert result is not None
+    assert result.checkpoint["channel_values"] == {"messages": ["written-async"]}
+    assert ("tk", "out", {"n": 2}) in result.pending_writes
+
+
+async def test_async_fallback_runs_sync_and_warns_once(
+    fallback_saver_and_container: tuple[Any, MockContainerClient],
+    caplog: Any,
+) -> None:
+    saver, _ = fallback_saver_and_container
+    cfg = _config(thread_id="t-fb")
+    checkpoint = _checkpoint(
+        "cp-fb",
+        channel_values={"messages": ["fb"]},
+        channel_versions={"messages": "v1"},
+    )
+    with caplog.at_level("WARNING"):
+        saved = await saver.aput(cfg, checkpoint, _metadata(), {"messages": "v1"})
+        result = await saver.aget_tuple(saved)
+        await saver.aput_writes(
+            _config(thread_id="t-fb", checkpoint_id="cp-fb"),
+            [("out", 1)],
+            task_id="tk",
+        )
+        listed = await _collect(saver.alist(_config(thread_id="t-fb")))
+
+    assert result is not None
+    assert result.checkpoint["channel_values"] == {"messages": ["fb"]}
+    assert [t.checkpoint["id"] for t in listed] == ["cp-fb"]
+    # Warning is emitted exactly once despite multiple async calls.
+    fallback_warnings = [
+        r for r in caplog.records if "aio_container_client" in r.getMessage()
+    ]
+    assert len(fallback_warnings) == 1
+
+
+async def test_aput_out_of_order_does_not_regress_latest(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, _ = async_saver_and_container
+    # Write cp-2 first, then an older cp-1: latest.json must still point at cp-2.
+    await saver.aput(
+        _config(thread_id="t-ord"),
+        _checkpoint("cp-2", channel_versions={"m": "v2"}, channel_values={"m": [2]}),
+        _metadata(step=2),
+        {"m": "v2"},
+    )
+    await saver.aput(
+        _config(thread_id="t-ord"),
+        _checkpoint("cp-1", channel_versions={"m": "v1"}, channel_values={"m": [1]}),
+        _metadata(step=1),
+        {"m": "v1"},
+    )
+    result = await saver.aget_tuple(_config(thread_id="t-ord"))
+    assert result is not None
+    assert result.checkpoint["id"] == "cp-2"
+
+
+async def test_aget_tuple_ignores_malformed_latest(
+    async_saver_and_container: tuple[Any, MockContainerClient],
+) -> None:
+    saver, container = async_saver_and_container
+    await saver.aput(
+        _config(thread_id="t-bad"),
+        _checkpoint("cp-1", channel_versions={"m": "v1"}, channel_values={"m": [1]}),
+        _metadata(),
+        {"m": "v1"},
+    )
+    latest = [n for n in container.blobs if n.endswith("latest.json")]
+    assert latest
+    container.blobs[latest[0]] = _BlobRecord(data=b"not-json", metadata={})
+    # Malformed hint is ignored; authoritative scan still resolves cp-1.
+    result = await saver.aget_tuple(_config(thread_id="t-bad"))
+    assert result is not None
+    assert result.checkpoint["id"] == "cp-1"


### PR DESCRIPTION
## Summary
- Adds genuine native async checkpoint I/O (`aget_tuple`/`alist`/`aput`/`aput_writes`) backed by the aio Azure Blob SDK (`azure.storage.blob.aio`), instead of `run_in_executor` wrappers around the sync client.
- Introduces an optional `aio_container_client` constructor param: when provided, async methods use non-blocking aio blob I/O; when omitted, they fall back to executor-wrapped sync with a one-time warning. Single class, fully backward-compatible.
- Preserves sync semantics on the async path: write ordering (values → metadata → checkpoint.bin commit marker → latest.json), monotonic latest-hint guard, empty-channel markers, parent metadata, and pending-write idempotency.

## Why
Native `ainvoke`/`astream` already shipped, but checkpoint I/O was still synchronous — a "half-async" gap. `BaseCheckpointSaver` async defaults raise `NotImplementedError` (they do not executor-wrap), so this makes `graph.ainvoke`/`astream` genuinely non-blocking with this saver.

## Testing
- `hatch run pytest tests/test_checkpointers_azure_blob.py` — 68 tests pass (incl. sync↔async cross-compatibility golden tests, fallback warn-once, out-of-order-put latest guard).
- Full suite coverage: **95.96%** (gate ≥95%).
- `make lint` ✓ · `make typecheck` ✓
- Reviewed by Oracle: no P0/P1 correctness defects; aio SDK usage, exception mapping (`ResourceNotFoundError`), and caller-owned client lifecycle all confirmed correct.

Closes #439