### PR TITLE
ci(deps): align langgraph-sdk max lane to the real <0.5 ceiling

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -152,6 +152,40 @@ jobs:
         # cannot mask coverage regressions -- the matrix job still enforces 95%.
         run: pytest tests/ --no-cov -q
 
+  langgraph-sdk-legacy:
+    name: langgraph-sdk compat (legacy 0.3.x)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install package and dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,azure-blob,azure-table]"
+
+      - name: Pin langgraph-sdk to the legacy supported line (>=0.3,<0.4)
+        # Supported-range map: min 0.2.2 (langgraph-min lane) / legacy 0.3.x
+        # (this lane) / max 0.4.x (langgraph-sdk-max lane). The floor is exercised
+        # by the langgraph-min lane (langgraph==1.0.0 resolves langgraph-sdk 0.2.2).
+        # This lane keeps the intermediate 0.3.x line covered so the platform-compat
+        # wire-shape contracts hold across the whole supported window (issues #340,
+        # #441).
+        run: pip install "langgraph-sdk>=0.3,<0.4"
+
+      - name: Show resolved versions
+        run: pip show langgraph langgraph-sdk | grep -E '^(Name|Version):'
+
+      - name: Run SDK contract tests against maximum langgraph-sdk
+        # Compatibility smoke only: `--no-cov` disables the coverage gate for
+        # this pinned run (a separate job from the coverage-enforcing matrix).
+        run: pytest tests/test_sdk_contracts.py tests/test_sdk_compat.py --no-cov -q
+
   langgraph-sdk-max:
     name: langgraph-sdk compat (max supported)
     runs-on: ubuntu-latest
@@ -169,12 +203,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev,azure-blob,azure-table]"
 
-      - name: Pin langgraph-sdk to the maximum supported line (<0.4)
-        # The floor is exercised by the langgraph-min lane (langgraph==1.0.0
-        # resolves langgraph-sdk 0.2.2). This lane proves the platform-compat
-        # wire-shape contracts also hold at the >=0.2.2,<0.4 ceiling so the
-        # supported range is verified at both ends (issue #340).
-        run: pip install "langgraph-sdk>=0.3,<0.4"
+      - name: Pin langgraph-sdk to the maximum supported line (>=0.4,<0.5)
+        # Supported-range map: min 0.2.2 / legacy 0.3.x / max 0.4.x. The runtime
+        # dep ceiling is langgraph-sdk<0.5 (pyproject), and langgraph core 1.2.9+
+        # pins langgraph-sdk>=0.4.2,<0.5. This lane proves the platform-compat
+        # wire-shape contracts hold at the real 0.4.x ceiling as a dedicated
+        # SDK-contract lane, not just transitively via langgraph-latest (#441).
+        run: pip install "langgraph-sdk>=0.4,<0.5"
 
       - name: Show resolved versions
         run: pip show langgraph langgraph-sdk | grep -E '^(Name|Version):'


### PR DESCRIPTION
## Summary
- The `langgraph-sdk compat (max supported)` lane pinned `>=0.3,<0.4`, but the real supported ceiling is `langgraph-sdk<0.5` (pyproject `>=0.2.2,<0.5`) and langgraph core 1.2.9+ pins `>=0.4.2,<0.5`. So 0.4.x was only covered transitively via the `langgraph-latest` lane, not as a dedicated SDK-contract lane.
- Renamed the old `>=0.3,<0.4` lane to **`langgraph-sdk compat (legacy 0.3.x)`** so the intermediate line stays covered.
- Added a new **`langgraph-sdk compat (max supported)`** lane pinning `>=0.4,<0.5` that runs `test_sdk_contracts.py` + `test_sdk_compat.py`.
- Comments now map the supported window: **min 0.2.2 / legacy 0.3.x / max 0.4.x**.

## Verification
- YAML parses; both `langgraph-sdk-legacy` and `langgraph-sdk-max` jobs present with correct pins.
- Both lanes run the SDK contract/compat suites (`--no-cov`, same as before).

Closes #441