### PR TITLE
docs: adopt rolling 0.x per-surface stability policy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,6 +8,15 @@
 4. **Azure Functions Native** — Use the v2 programming model directly, no intermediate web framework.
 5. **Checkpointer Agnostic** — Users bring their own checkpointer; we pass config through.
 
+## Stability policy
+
+This project follows a **rolling 0.x** development model: core adapter APIs aim
+for backward compatibility across minor releases while newer surfaces may still
+evolve. The canonical **per-surface stability table** (Stable / Beta /
+Experimental) lives near the top of [`README.md`](README.md) and is the single
+source of truth; the `Development Status :: 3 - Alpha` classifier reflects the
+youngest surfaces, not the stable core.
+
 ## Architecture
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-> **Alpha Notice** — This package is under active development. The `Development Status :: 3 - Alpha` classifier in `pyproject.toml` is the source of truth: expect breaking changes between minor versions until v1.0. Please report issues on GitHub.
+> **Stability — rolling 0.x, per surface.** This package follows a rolling 0.x development model rather than a single "everything breaks until v1.0" contract. Core adapter APIs aim for backward compatibility across minor releases, while newer surfaces may still evolve. The per-surface stability table below is the single source of truth for what you can rely on; the `Development Status :: 3 - Alpha` classifier in `pyproject.toml` reflects the youngest surfaces, not the stable core. Please report issues on GitHub.
+>
+> | Surface | Tier | What it means |
+> | --- | --- | --- |
+> | Core — `LangGraphApp` construction, native invoke / stream / state HTTP endpoints, auth levels | **Stable** | API frozen; a breaking change warrants a major bump |
+> | Checkpoint backends, thread locking, native async runtime (`ainvoke`/`astream`), `version="v2"` pass-through, `RunObserver` contract | **Beta** | Shape settled; may be refined before v1.0 |
+> | LangGraph Platform compatibility, true HTTP streaming, Azure Service Bus trigger, Durable async run lifecycle | **Experimental** | May change or be removed between minor releases |
 
 Deploy [LangGraph](https://github.com/langchain-ai/langgraph) graphs as **Azure Functions** HTTP endpoints with minimal boilerplate.
 


### PR DESCRIPTION
## Summary
- Replaces the blanket "expect breaking changes between minor versions until v1.0" Alpha Notice (README top) with a **rolling 0.x** statement and a **per-surface stability table** as the single source of truth.
- Tiers (aligned with the roadmap #410): **Stable** (core `LangGraphApp` + native invoke/stream/state + auth), **Beta** (checkpointers, thread locking, native async, `version="v2"`, `RunObserver`), **Experimental** (Platform compat, true streaming, Service Bus, Durable).
- Clarifies the `Development Status :: 3 - Alpha` classifier reflects the youngest surfaces, not the stable core (no classifier change — behavior unchanged).
- Adds a short "Stability policy" pointer in `DESIGN.md` referencing the canonical README table.

## Notes
- Translated READMEs are best-effort per `AGENTS.md`; their staleness banners are untouched and not blocking.

Closes #426