### PR TITLE
feat(app): reject async-only graphs under platform_compat

### DIFF
--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -354,6 +354,17 @@ response_model: Optional Pydantic model class for response body
                 "Graph must have an invoke() or ainvoke() method. "
                 f"Got {type(graph).__name__}"
             )
+        if self.platform_compat and has_async_invoke and not has_sync_invoke:
+            raise TypeError(
+                f"Graph {name!r} exposes only async methods (ainvoke/astream), "
+                "but platform_compat=True. LangGraph Platform-compatible runs "
+                "(/runs/wait, /runs/stream, /threads/{id}/runs/*) execute graphs "
+                "through synchronous invoke()/stream() calls, so an async-only "
+                "graph cannot be served on the Platform surface. Provide a graph "
+                "that also exposes invoke()/stream() (e.g. a standard compiled "
+                "LangGraph graph), or register it on a LangGraphApp without "
+                "platform_compat=True to use the native async endpoints."
+            )
         _validate_optional_model(request_model, "request_model")
         _validate_optional_model(response_model, "response_model")
         name_err = validate_graph_name(name)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -95,6 +95,61 @@ class TestRegistration:
         app.register(graph=fake_invoke_only_graph, name="invoke_only")
         assert "invoke_only" in app._registrations
 
+    def test_register_async_only_graph_allowed_without_platform_compat(self) -> None:
+        """An async-only graph registers fine on the native (non-platform) app."""
+
+        class _AsyncOnlyGraph:
+            checkpointer = None
+
+            async def ainvoke(
+                self, input: dict[str, Any], config: dict[str, Any] | None = None
+            ) -> dict[str, Any]:
+                return {"ok": True}
+
+            async def astream(
+                self,
+                input: dict[str, Any],
+                config: dict[str, Any] | None = None,
+                stream_mode: str = "values",
+            ) -> Any:
+                yield {"ok": True}
+
+        app = LangGraphApp()
+        app.register(graph=_AsyncOnlyGraph(), name="async_only")
+        assert "async_only" in app._registrations
+
+    def test_register_async_only_graph_rejected_with_platform_compat(self) -> None:
+        """platform_compat rejects async-only graphs: Platform runs call sync invoke()."""
+
+        class _AsyncOnlyGraph:
+            checkpointer = None
+
+            async def ainvoke(
+                self, input: dict[str, Any], config: dict[str, Any] | None = None
+            ) -> dict[str, Any]:
+                return {"ok": True}
+
+            async def astream(
+                self,
+                input: dict[str, Any],
+                config: dict[str, Any] | None = None,
+                stream_mode: str = "values",
+            ) -> Any:
+                yield {"ok": True}
+
+        app = LangGraphApp(platform_compat=True)
+        with pytest.raises(TypeError, match="only async methods"):
+            app.register(graph=_AsyncOnlyGraph(), name="async_only")
+        assert "async_only" not in app._registrations
+
+    def test_register_sync_graph_allowed_with_platform_compat(
+        self, fake_graph: FakeCompiledGraph
+    ) -> None:
+        """A graph exposing sync invoke() is accepted under platform_compat."""
+        app = LangGraphApp(platform_compat=True)
+        app.register(graph=fake_graph, name="agent")
+        assert "agent" in app._registrations
+
     def test_register_with_auth_level_override(self, fake_graph: FakeCompiledGraph) -> None:
         app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
         app.register(graph=fake_graph, name="agent", auth_level=func.AuthLevel.ADMIN)


### PR DESCRIPTION
## Context

LangGraph Platform-compatible runs (`/runs/wait`, `/runs/stream`, `/threads/{id}/runs/*`) execute graphs through **synchronous** `invoke()` / `stream()` calls (see `platform/_runs.py`). An async-only graph — one exposing `ainvoke`/`astream` but no sync `invoke` — previously registered successfully on a `platform_compat=True` app, then failed at request time with an opaque error.

## What changed

- `LangGraphApp.register()` now fails fast with a clear `TypeError` when `platform_compat=True` and the graph exposes only async methods. The message explains the graph must provide sync `invoke()`/`stream()` for the Platform surface, or be registered on a native (non-platform) app to use the async endpoints.
- Native async registration (`platform_compat=False`) is **unchanged** — async-only graphs still register and serve on the native async endpoints.

## Acceptance Checklist

- [x] Async-only graph rejected under `platform_compat=True` (clear `TypeError`)
- [x] Async-only graph still allowed on native (non-platform) app
- [x] Sync graph still allowed under `platform_compat=True`
- [x] `make lint` / `make typecheck` clean
- [x] Coverage 95.98% (≥ 95% gate)

Closes #442