### PR TITLE
feat(observability): add optional OpenTelemetry RunObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,38 @@ these under `customDimensions`.
 > KQL walkthrough, see
 > [`examples/observability_app_insights/`](examples/observability_app_insights/).
 
+#### OpenTelemetry observer (optional `otel` extra)
+
+For distributed-tracing backends, the package ships an optional
+`OTelRunObserver` that maps each run's lifecycle to a single OpenTelemetry
+span. It is gated behind the `otel` extra:
+
+```bash
+pip install azure-functions-langgraph[otel]
+```
+
+```python
+from azure_functions_langgraph import LangGraphApp, OTelRunObserver
+
+# Uses whatever TracerProvider the operator has already installed.
+app = LangGraphApp(observer=OTelRunObserver())
+app.register(graph=graph, name="my_agent")
+```
+
+`on_run_started` opens a span (keyed by `run_id`); the terminal event
+(`completed` / `failed` / `rejected`) closes it with the matching
+`StatusCode`, a `langgraph.status`, and a `langgraph.duration_ms`. Span
+attributes come **only** from the safe `RunContext` correlation fields — never
+input, output, config, headers, or secrets — and failures record the exception
+*type* only.
+
+> Consistent with the observability boundary above, `OTelRunObserver` **does
+> not** configure a `TracerProvider`, exporters, sampling, or resource
+> attributes — the operator owns all SDK/exporter wiring. The observer only
+> acquires a tracer via `opentelemetry.trace.get_tracer(...)` and emits spans
+> onto whatever provider is installed. For a runnable local demo with a console
+> exporter, see [`examples/run_observer_otel/`](examples/run_observer_otel/).
+
 ### Per-graph auth
 
 Override app-level auth settings per graph:

--- a/examples/run_observer_otel/README.md
+++ b/examples/run_observer_otel/README.md
@@ -1,0 +1,120 @@
+# OpenTelemetry Run Observer Example
+
+Demonstrates the **optional OpenTelemetry observer** (issue #434), which layers
+on top of the run-lifecycle observability contract (issues #425 / #407). The app
+registers an [`OTelRunObserver`](../../src/azure_functions_langgraph/observability_otel.py)
+that maps every native `invoke`/`stream` run to a single OpenTelemetry span:
+
+- `on_run_started` → **starts** a span (`langgraph.run.invoke` / `.stream`).
+- `on_run_completed` → ends the span with `StatusCode.OK`.
+- `on_run_failed` → records the exception (class/type only), sets
+  `StatusCode.ERROR`, and ends the span.
+- `on_run_rejected` → a run that never reached the graph opens and immediately
+  ends a short span tagged with the rejection reason.
+
+The graph itself is deterministic — no LLM calls — so the example runs in CI
+without any cloud credentials.
+
+## Install behind the `otel` extra
+
+The observer is gated behind an optional extra so base installs stay lean:
+
+```bash
+pip install "azure-functions-langgraph[otel]"
+```
+
+Importing `OTelRunObserver` without the extra raises a friendly error naming it.
+
+## No payloads, no secrets
+
+Span attributes come **only** from the safe `RunContext` correlation fields —
+`langgraph.graph_name`, `langgraph.endpoint`, `langgraph.run_id`,
+`langgraph.thread_id`, `langgraph.assistant_id`, `langgraph.stream_mode`,
+`langgraph.transport`, `langgraph.has_checkpointer`, `langgraph.lock_backend`,
+plus a terminal `langgraph.duration_ms` and `langgraph.status`. Never input,
+output, config, headers, or secrets.
+
+## The package owns the domain signal only
+
+`OTelRunObserver` acquires a tracer via `opentelemetry.trace.get_tracer(...)` and
+emits spans onto **whatever `TracerProvider` you install**. It does **not**
+configure a provider, exporter, sampling, or resource attributes — that is
+operator-owned. This example's `function_app.py` wires a **console exporter**
+locally so `func start` prints spans; in production, use the Azure Functions
+Application Insights integration, the OpenTelemetry distro, or an OTLP exporter
+you configure.
+
+## Opt-in registration
+
+```python
+from azure_functions_langgraph import LangGraphApp
+from azure_functions_langgraph.observability_otel import OTelRunObserver
+
+app = LangGraphApp(observer=OTelRunObserver())
+```
+
+Observer callbacks are isolated — an exception raised inside an observer is
+swallowed and logged, and never changes the HTTP response or interferes with
+thread-lock release.
+
+## Prerequisites
+
+- [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) v4+
+- Python 3.10+
+- `langgraph>=1.1`
+
+## Run locally
+
+```bash
+cd examples/run_observer_otel
+cp local.settings.json.example local.settings.json
+pip install -r requirements.txt
+func start
+```
+
+## Test
+
+### Invoke (emits `on_run_started` → `on_run_completed`)
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/run_observer_otel/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"user_text": "Ada", "history": [], "turn_count": 0}}'
+```
+
+```json
+{"output": {"user_text": "Ada", "history": ["Hello, Ada!"], "turn_count": 1, "last_reply": "Hello, Ada!"}}
+```
+
+The Functions host log shows the console-exported span, e.g.:
+
+```
+{
+  "name": "langgraph.run.invoke",
+  "status": {"status_code": "OK"},
+  "attributes": {
+    "langgraph.graph_name": "run_observer_otel",
+    "langgraph.endpoint": "invoke",
+    "langgraph.run_id": "...",
+    "langgraph.status": "completed",
+    "langgraph.duration_ms": 1.2
+  }
+}
+```
+
+### Rejected run (emits `on_run_rejected`)
+
+```bash
+curl -X POST http://localhost:7071/api/graphs/run_observer_otel/invoke \
+  -H "Content-Type: application/json" \
+  -d 'not json'
+```
+
+The span carries `"langgraph.status": "rejected"` and
+`"langgraph.reject_reason": "invalid_request"` with `StatusCode.ERROR`.
+
+### Health check
+
+```bash
+curl http://localhost:7071/api/health
+```

--- a/examples/run_observer_otel/function_app.py
+++ b/examples/run_observer_otel/function_app.py
@@ -1,0 +1,63 @@
+"""OTel run-observer example - Azure Functions entry point.
+
+Demonstrates the optional OpenTelemetry observer (issue #434): an
+:class:`OTelRunObserver` is registered on ``LangGraphApp`` and maps every native
+invoke/stream run lifecycle event (started / completed / failed / rejected) to
+an OpenTelemetry span carrying only **safe correlation fields** — never input,
+output, config, or secrets.
+
+Boundary: the package owns the domain signal only. It does **not** configure a
+``TracerProvider`` or exporters — the operator owns all SDK/exporter wiring. In
+Azure Functions, the Application Insights integration (or the OpenTelemetry
+distro / an OTLP exporter you configure) collects the spans. This example wires
+a console exporter locally so ``func start`` prints the spans to the host log.
+
+Run from this directory:
+    pip install "azure-functions-langgraph[otel]" opentelemetry-sdk "langgraph>=1.1"
+    func start
+"""
+
+from __future__ import annotations
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+from azure_functions_langgraph.observability_otel import OTelRunObserver
+
+
+def _configure_local_tracer() -> None:
+    """Wire a console span exporter for local `func start` demos.
+
+    This is **operator-owned** SDK configuration living in the example, not in
+    the package. In production, replace it with your Application Insights /
+    OpenTelemetry distro / OTLP exporter setup. If the OTel SDK is not
+    installed, the observer still works — spans are simply dropped by the
+    default no-op provider.
+    """
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            ConsoleSpanExporter,
+            SimpleSpanProcessor,
+        )
+    except ImportError:
+        return
+
+    if isinstance(trace.get_tracer_provider(), TracerProvider):
+        return  # A provider is already installed; don't override the operator's.
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+
+_configure_local_tracer()
+
+langgraph_app = LangGraphApp(observer=OTelRunObserver())
+langgraph_app.register(
+    graph=compiled_graph,
+    name="run_observer_otel",
+    description="A deterministic agent with an OpenTelemetry RunObserver (issue #434)",
+)
+
+app = langgraph_app.function_app

--- a/examples/run_observer_otel/graph.py
+++ b/examples/run_observer_otel/graph.py
@@ -1,0 +1,63 @@
+"""OTel run-observer example: a deterministic graph to exercise OTel tracing.
+
+This example demonstrates the optional OpenTelemetry observer (issue #434),
+which layers on top of the run-lifecycle observability contract (#425/#407).
+The graph itself is deliberately deterministic — no LLM calls — so the example
+runs in CI without any cloud credentials. The interesting part lives in
+``function_app.py``, which wires an :class:`OTelRunObserver` onto the app.
+
+Requirements::
+
+    pip install "azure-functions-langgraph[otel]" "langgraph>=1.1"
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+
+class ChatState(TypedDict, total=False):
+    user_text: str
+    history: list[str]
+    turn_count: int
+    last_reply: str
+
+
+def greet(state: ChatState) -> dict[str, Any]:
+    """First node — build a greeting."""
+    text = state.get("user_text", "")
+    reply = f"Hello, {text}!" if text else "Hello!"
+    return {"history": [*state.get("history", []), reply], "last_reply": reply}
+
+
+def count(state: ChatState) -> dict[str, Any]:
+    """Second node — increment the turn counter."""
+    return {"turn_count": (state.get("turn_count") or 0) + 1}
+
+
+# NOTE: guarded so the module can be imported without langgraph installed
+# (e.g. for testing the example structure).
+try:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(ChatState)
+    builder.add_node("greet", greet)
+    builder.add_node("count", count)
+    builder.add_edge(START, "greet")
+    builder.add_edge("greet", "count")
+    builder.add_edge("count", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError:
+    raise ImportError(
+        "langgraph is required for this example. "
+        "Install it with: pip install 'langgraph>=1.1' langchain-core"
+    )

--- a/examples/run_observer_otel/host.json
+++ b/examples/run_observer_otel/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/run_observer_otel/local.settings.json.example
+++ b/examples/run_observer_otel/local.settings.json.example
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}

--- a/examples/run_observer_otel/requirements.txt
+++ b/examples/run_observer_otel/requirements.txt
@@ -1,0 +1,11 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+# OpenTelemetry observer lives behind the [otel] extra
+azure-functions-langgraph[otel]==0.1.0a0
+# The OTel SDK + an exporter are operator-owned; installed here for the local demo
+opentelemetry-sdk>=1.20,<2
+# run observability contract works on any supported LangGraph version
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ sqlite = [
 cosmos = [
     "langgraph-checkpoint-cosmosdb>=0.2.0,<0.3",
 ]
+otel = [
+    "opentelemetry-api>=1.20,<2",
+]
 dev = [
     "bandit==1.9.4",
     "build",
@@ -82,6 +85,10 @@ dev = [
     # `langgraph-min` lane (langgraph==1.0.0 -> langgraph-sdk 0.2.2) still resolves.
     "langgraph-sdk>=0.2.2,<0.5",
     "langgraph-checkpoint-conformance>=0.0.2,<0.1",
+    # OpenTelemetry for the optional OTelRunObserver (otel extra) test suite.
+    # SDK + in-memory exporter are test-only; the runtime extra needs only the API.
+    "opentelemetry-api>=1.20,<2",
+    "opentelemetry-sdk>=1.20,<2",
 ]
 docs = [
     "mkdocs<2.0",

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -73,11 +73,18 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RunRejectedReason": ("azure_functions_langgraph.observability", "RunRejectedReason"),
     "RunTransport": ("azure_functions_langgraph.observability", "RunTransport"),
     "LoggingRunObserver": ("azure_functions_langgraph.observability", "LoggingRunObserver"),
+    "OTelRunObserver": ("azure_functions_langgraph.observability_otel", "OTelRunObserver"),
 }
 
 # Symbols whose import failure means the optional runtime deps are missing;
 # surface a friendly install hint instead of the raw ImportError.
 _REQUIRES_RUNTIME_DEPS = frozenset({"LangGraphApp"})
+
+# Symbols whose import failure means an optional extra is missing; surface an
+# install hint naming the extra instead of the raw ImportError.
+_REQUIRES_EXTRA: dict[str, str] = {
+    "OTelRunObserver": "otel",
+}
 
 
 def __getattr__(name: str) -> object:
@@ -92,6 +99,12 @@ def __getattr__(name: str) -> object:
             raise ImportError(
                 "LangGraphApp requires 'azure-functions' and 'langgraph'. "
                 "Install them with: pip install azure-functions-langgraph"
+            ) from exc
+        extra = _REQUIRES_EXTRA.get(name)
+        if extra is not None:
+            raise ImportError(
+                f"{name} requires the optional {extra!r} extra. "
+                f"Install it with: pip install azure-functions-langgraph[{extra}]"
             ) from exc
         raise
     return getattr(module, attr)
@@ -128,4 +141,5 @@ __all__ = [
     "RunRejectedReason",
     "RunTransport",
     "LoggingRunObserver",
+    "OTelRunObserver",
 ]

--- a/src/azure_functions_langgraph/observability_otel.py
+++ b/src/azure_functions_langgraph/observability_otel.py
@@ -1,0 +1,158 @@
+"""Optional OpenTelemetry :class:`RunObserver` (issue #434).
+
+This module layers an OpenTelemetry-backed observer on top of the
+dependency-free run-observability contract in
+:mod:`azure_functions_langgraph.observability`. It is gated behind the
+``otel`` extra::
+
+    pip install azure-functions-langgraph[otel]
+
+Design boundary — the package owns the **domain signal only**:
+
+- It creates spans from the *safe* :class:`RunContext` correlation fields and
+  nothing else (no input, output, config, headers, or secrets).
+- It does **not** configure a global ``TracerProvider``, exporters, sampling,
+  or resource attributes. The operator owns all SDK/exporter wiring; this
+  observer merely acquires a tracer via :func:`opentelemetry.trace.get_tracer`
+  and emits spans onto whatever provider the operator installed.
+
+Span lifetime is threaded across two separate lifecycle callbacks
+(``on_run_started`` starts a span; the terminal event ends it), keyed by
+``run_id`` — exactly the error-prone glue this observer exists to remove.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from opentelemetry import trace
+from opentelemetry.trace import Span, Status, StatusCode, Tracer
+from opentelemetry.util.types import AttributeValue
+
+from azure_functions_langgraph.observability import (
+    RunContext,
+    RunRejectedReason,
+    _duration_ms,
+)
+
+# Instrumentation scope name for the tracer acquired by default. Operators can
+# filter/route spans by this scope in their exporter configuration.
+INSTRUMENTATION_NAME = "azure_functions_langgraph"
+
+# Attribute namespace for every span attribute this observer sets, so operators
+# get a stable, greppable, collision-free prefix in their backend.
+_ATTR_PREFIX = "langgraph"
+
+
+def _safe_attributes(ctx: RunContext) -> dict[str, AttributeValue]:
+    """Build the OTel attribute set from *only* safe correlation fields.
+
+    ``None`` values are dropped (OpenTelemetry attributes cannot be ``None``)
+    and the immutable ``stream_mode`` tuple is coerced to a list so it is a
+    valid homogeneous attribute sequence.
+    """
+    stream_mode: AttributeValue | None
+    if isinstance(ctx.stream_mode, tuple):
+        stream_mode = list(ctx.stream_mode)
+    else:
+        stream_mode = ctx.stream_mode
+
+    raw: dict[str, AttributeValue | None] = {
+        f"{_ATTR_PREFIX}.graph_name": ctx.graph_name,
+        f"{_ATTR_PREFIX}.endpoint": ctx.endpoint,
+        f"{_ATTR_PREFIX}.run_id": ctx.run_id,
+        f"{_ATTR_PREFIX}.thread_id": ctx.thread_id,
+        f"{_ATTR_PREFIX}.assistant_id": ctx.assistant_id,
+        f"{_ATTR_PREFIX}.invocation_id": ctx.invocation_id,
+        f"{_ATTR_PREFIX}.stream_mode": stream_mode,
+        f"{_ATTR_PREFIX}.transport": ctx.transport,
+        f"{_ATTR_PREFIX}.has_checkpointer": ctx.has_checkpointer,
+        f"{_ATTR_PREFIX}.lock_backend": ctx.lock_backend,
+    }
+    return {key: value for key, value in raw.items() if value is not None}
+
+
+class OTelRunObserver:
+    """A :class:`RunObserver` that maps run lifecycle events to OTel spans.
+
+    One span is produced per run:
+
+    - :meth:`on_run_started` starts a span and stores it keyed by ``run_id``.
+    - :meth:`on_run_completed` ends that span with ``StatusCode.OK``.
+    - :meth:`on_run_failed` records the exception (class/type only — never a
+      payload), sets ``StatusCode.ERROR``, and ends the span.
+    - :meth:`on_run_rejected` — which has no preceding ``on_run_started`` — opens
+      and immediately ends a short span marked with the rejection reason.
+
+    All span attributes come from :func:`_safe_attributes`; a terminal
+    ``langgraph.duration_ms`` and ``langgraph.status`` are added on close.
+
+    Args:
+        tracer: An OpenTelemetry :class:`~opentelemetry.trace.Tracer` to emit
+            on. Defaults to ``trace.get_tracer(INSTRUMENTATION_NAME)`` resolved
+            against whatever ``TracerProvider`` the operator has installed.
+        span_name_prefix: Prefix for span names; the span is named
+            ``"{span_name_prefix}.{endpoint}"`` (e.g. ``"langgraph.run.invoke"``).
+    """
+
+    def __init__(
+        self,
+        tracer: Tracer | None = None,
+        *,
+        span_name_prefix: str = "langgraph.run",
+    ) -> None:
+        self._tracer: Tracer = tracer or trace.get_tracer(INSTRUMENTATION_NAME)
+        self._span_name_prefix = span_name_prefix
+        # run_id -> live span, guarded so concurrent runs never corrupt the map.
+        self._spans: dict[str, Span] = {}
+        self._lock = threading.Lock()
+
+    def _span_name(self, ctx: RunContext) -> str:
+        return f"{self._span_name_prefix}.{ctx.endpoint}"
+
+    def on_run_started(self, ctx: RunContext) -> None:
+        span = self._tracer.start_span(
+            self._span_name(ctx),
+            attributes=_safe_attributes(ctx),
+        )
+        with self._lock:
+            self._spans[ctx.run_id] = span
+
+    def _pop_span(self, run_id: str) -> Span | None:
+        with self._lock:
+            return self._spans.pop(run_id, None)
+
+    def _finalize(self, span: Span, ctx: RunContext, status: str) -> None:
+        duration = _duration_ms(ctx)
+        if duration is not None:
+            span.set_attribute(f"{_ATTR_PREFIX}.duration_ms", duration)
+        span.set_attribute(f"{_ATTR_PREFIX}.status", status)
+
+    def on_run_completed(self, ctx: RunContext) -> None:
+        span = self._pop_span(ctx.run_id)
+        if span is None:
+            return
+        self._finalize(span, ctx, "completed")
+        span.set_status(Status(StatusCode.OK))
+        span.end()
+
+    def on_run_failed(self, ctx: RunContext, exc: BaseException) -> None:
+        span = self._pop_span(ctx.run_id)
+        if span is None:
+            return
+        self._finalize(span, ctx, "failed")
+        span.set_attribute(f"{_ATTR_PREFIX}.error_type", type(exc).__name__)
+        span.record_exception(exc)
+        span.set_status(Status(StatusCode.ERROR, type(exc).__name__))
+        span.end()
+
+    def on_run_rejected(self, ctx: RunContext, reason: RunRejectedReason) -> None:
+        # Rejections never emit on_run_started, so open a self-contained span.
+        span = self._tracer.start_span(
+            self._span_name(ctx),
+            attributes=_safe_attributes(ctx),
+        )
+        self._finalize(span, ctx, "rejected")
+        span.set_attribute(f"{_ATTR_PREFIX}.reject_reason", reason)
+        span.set_status(Status(StatusCode.ERROR, f"rejected: {reason}"))
+        span.end()

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -24,6 +24,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("async_agent", "compiled_graph"),
     ("run_observer", "compiled_graph"),
     ("observability_app_insights", "compiled_graph"),
+    ("run_observer_otel", "compiled_graph"),
 )
 
 
@@ -79,6 +80,7 @@ EXAMPLE_DIRS = (
     "async_agent",
     "run_observer",
     "observability_app_insights",
+    "run_observer_otel",
 )
 
 

--- a/tests/test_observability_otel.py
+++ b/tests/test_observability_otel.py
@@ -1,0 +1,219 @@
+"""Tests for the optional OpenTelemetry RunObserver (issue #434)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+import pytest
+
+from azure_functions_langgraph.observability import (
+    RunContext,
+    RunObserver,
+    finish_context,
+    new_run_context,
+)
+from azure_functions_langgraph.observability_otel import (
+    OTelRunObserver,
+    _safe_attributes,
+)
+
+
+def _attrs(span: Any) -> dict[str, Any]:
+    """Narrow a span's Optional attribute mapping for typed indexing."""
+    attributes = span.attributes
+    assert attributes is not None
+    return dict(attributes)
+
+
+@pytest.fixture
+def exporter() -> InMemorySpanExporter:
+    """A fresh in-memory exporter wired to its own provider/tracer.
+
+    Uses an isolated ``TracerProvider`` (not the global one) so tests never
+    depend on process-wide OTel state or leak spans between cases.
+    """
+    return InMemorySpanExporter()
+
+
+@pytest.fixture
+def observer(exporter: InMemorySpanExporter) -> OTelRunObserver:
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    return OTelRunObserver(tracer=tracer)
+
+
+def _started(graph_name: str = "agent", endpoint: str = "invoke", **kw: object) -> RunContext:
+    ctx = new_run_context(graph_name, endpoint, **kw)  # type: ignore[arg-type]
+    return ctx
+
+
+class TestProtocolConformance:
+    def test_satisfies_run_observer_protocol(self, observer: OTelRunObserver) -> None:
+        assert isinstance(observer, RunObserver)
+
+    def test_default_tracer_resolves_without_error(self) -> None:
+        # No tracer passed → falls back to trace.get_tracer(); must not raise.
+        obs = OTelRunObserver()
+        assert isinstance(obs, RunObserver)
+
+
+class TestSuccessLifecycle:
+    def test_started_then_completed_emits_ok_span(
+        self, observer: OTelRunObserver, exporter: InMemorySpanExporter
+    ) -> None:
+        ctx = _started(thread_id="t1", assistant_id="a1")
+        observer.on_run_started(ctx)
+        # Span not exported until it ends.
+        assert exporter.get_finished_spans() == ()
+        observer.on_run_completed(finish_context(ctx))
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "langgraph.run.invoke"
+        assert span.status.status_code == StatusCode.OK
+        assert _attrs(span)["langgraph.graph_name"] == "agent"
+        assert _attrs(span)["langgraph.thread_id"] == "t1"
+        assert _attrs(span)["langgraph.assistant_id"] == "a1"
+        assert _attrs(span)["langgraph.status"] == "completed"
+        assert _attrs(span)["langgraph.duration_ms"] >= 0
+
+    def test_stream_endpoint_names_span(
+        self, observer: OTelRunObserver, exporter: InMemorySpanExporter
+    ) -> None:
+        ctx = _started(endpoint="stream", stream_mode=["values", "updates"])
+        observer.on_run_started(ctx)
+        observer.on_run_completed(finish_context(ctx))
+        span = exporter.get_finished_spans()[0]
+        assert span.name == "langgraph.run.stream"
+        # Tuple stream_mode is coerced to a list for a valid OTel attribute.
+        assert _attrs(span)["langgraph.stream_mode"] == ("values", "updates")
+
+
+class TestFailureLifecycle:
+    def test_started_then_failed_records_exception(
+        self, observer: OTelRunObserver, exporter: InMemorySpanExporter
+    ) -> None:
+        ctx = _started()
+        observer.on_run_started(ctx)
+        observer.on_run_failed(finish_context(ctx), ValueError("boom"))
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert _attrs(span)["langgraph.status"] == "failed"
+        assert _attrs(span)["langgraph.error_type"] == "ValueError"
+        # The exception is recorded as a span event, class only — no payload.
+        assert any(e.name == "exception" for e in span.events)
+
+
+class TestRejectedLifecycle:
+    def test_rejected_emits_self_contained_span(
+        self, observer: OTelRunObserver, exporter: InMemorySpanExporter
+    ) -> None:
+        # Rejections never call on_run_started.
+        ctx = finish_context(_started())
+        observer.on_run_rejected(ctx, "invalid_request")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert _attrs(span)["langgraph.status"] == "rejected"
+        assert _attrs(span)["langgraph.reject_reason"] == "invalid_request"
+
+
+class TestEdgeCases:
+    def test_terminal_without_started_is_ignored(
+        self, observer: OTelRunObserver, exporter: InMemorySpanExporter
+    ) -> None:
+        # A terminal event for an unknown run_id must be a no-op, not a crash.
+        observer.on_run_completed(finish_context(_started()))
+        observer.on_run_failed(finish_context(_started()), RuntimeError("x"))
+        assert exporter.get_finished_spans() == ()
+
+    def test_concurrent_runs_tracked_independently(
+        self, observer: OTelRunObserver, exporter: InMemorySpanExporter
+    ) -> None:
+        a = _started(graph_name="a")
+        b = _started(graph_name="b")
+        observer.on_run_started(a)
+        observer.on_run_started(b)
+        observer.on_run_completed(finish_context(b))
+        observer.on_run_failed(finish_context(a), KeyError("k"))
+
+        spans = {_attrs(s)["langgraph.graph_name"]: s for s in exporter.get_finished_spans()}
+        assert spans["b"].status.status_code == StatusCode.OK
+        assert spans["a"].status.status_code == StatusCode.ERROR
+
+    def test_custom_span_name_prefix(self, exporter: InMemorySpanExporter) -> None:
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        obs = OTelRunObserver(tracer=provider.get_tracer("t"), span_name_prefix="myagent")
+        ctx = _started()
+        obs.on_run_started(ctx)
+        obs.on_run_completed(finish_context(ctx))
+        assert exporter.get_finished_spans()[0].name == "myagent.invoke"
+
+
+class TestSafeAttributes:
+    def test_none_fields_are_dropped(self) -> None:
+        ctx = _started()  # thread_id/assistant_id/etc default to None
+        attrs = _safe_attributes(ctx)
+        assert "langgraph.thread_id" not in attrs
+        assert "langgraph.assistant_id" not in attrs
+        # Always-present safe fields remain.
+        assert attrs["langgraph.graph_name"] == "agent"
+        assert attrs["langgraph.transport"] == "buffered"
+
+    def test_no_payload_fields_leak(self) -> None:
+        ctx = _started(thread_id="t", has_checkpointer=True, lock_backend="inprocess")
+        attrs = _safe_attributes(ctx)
+        # Only the known safe correlation keys — no input/output/config/headers.
+        allowed_suffixes = {
+            "graph_name",
+            "endpoint",
+            "run_id",
+            "thread_id",
+            "assistant_id",
+            "invocation_id",
+            "stream_mode",
+            "transport",
+            "has_checkpointer",
+            "lock_backend",
+        }
+        for key in attrs:
+            assert key.split(".", 1)[1] in allowed_suffixes
+
+
+def test_missing_extra_raises_friendly_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Accessing OTelRunObserver without opentelemetry names the 'otel' extra."""
+    import builtins
+    import importlib
+    import sys
+
+    import azure_functions_langgraph
+
+    # Drop any cached observer module and force the otel import to fail.
+    monkeypatch.delitem(sys.modules, "azure_functions_langgraph.observability_otel", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "opentelemetry" or name.startswith("opentelemetry."):
+            raise ImportError("no opentelemetry")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    importlib.reload(azure_functions_langgraph)
+    try:
+        with pytest.raises(ImportError, match=r"otel.*extra"):
+            _ = azure_functions_langgraph.OTelRunObserver
+    finally:
+        monkeypatch.undo()
+        importlib.reload(azure_functions_langgraph)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -49,6 +49,7 @@ def test_all_exports() -> None:
     assert "NoOpRunObserver" in azure_functions_langgraph.__all__
     assert "RunRejectedReason" in azure_functions_langgraph.__all__
     assert "LoggingRunObserver" in azure_functions_langgraph.__all__
+    assert "OTelRunObserver" in azure_functions_langgraph.__all__
     assert "RunTransport" in azure_functions_langgraph.__all__
 
 


### PR DESCRIPTION
## Context

Closes #434. Adds an optional OpenTelemetry-backed `RunObserver` so teams on a distributed-tracing backend get run-lifecycle spans without hand-writing the span-lifetime glue.

## Summary

- **`OTelRunObserver`** (`observability_otel.py`) — maps each run to a single OTel span keyed by `run_id`: `on_run_started` opens the span, the terminal event (`completed`/`failed`/`rejected`) closes it with the matching `StatusCode`, `langgraph.status`, and `langgraph.duration_ms`. Failures record the exception *type* only. Span map guarded by a lock for concurrent runs.
- **Safe attributes only** — attributes derive exclusively from the safe `RunContext` correlation fields (never input/output/config/headers/secrets); `None` values dropped, tuple `stream_mode` coerced to list.
- **Domain signal only** — the observer never configures a `TracerProvider`, exporters, sampling, or resource attributes; it acquires a tracer via `trace.get_tracer(...)` and emits onto whatever provider the operator installed. Observer failures stay isolated from graph runs.
- **`otel` extra** + lazy export with a friendly missing-dependency `ImportError` naming the extra.
- **Docs + example** — README "OpenTelemetry observer" subsection and a runnable `examples/run_observer_otel/` (console exporter), registered in the examples smoke test.

## Verification

- `make lint` OK, `make typecheck` OK (mypy strict, 77 files)
- Full suite green, coverage **96.06%** (>=95% gate), incl. 12 new OTel unit tests covering success/failure/rejected lifecycles, concurrent runs, terminal-without-start no-op, safe-attribute filtering, and the missing-extra friendly error.

## Out of scope

- Exporter/sampling/provider configuration (operator-owned by design).