### PR TITLE
feat(triggers): add Azure Service Bus trigger adapter (#409)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,73 @@ input, output, config, headers, or secrets — and failures record the exception
 > onto whatever provider is installed. For a runnable local demo with a console
 > exporter, see [`examples/run_observer_otel/`](examples/run_observer_otel/).
 
+### Service Bus trigger (experimental)
+
+Beyond the HTTP surface, a compiled graph can be driven directly from an
+**Azure Service Bus** message via `register_service_bus`. Each delivered
+message is mapped to a single `invoke` (or `ainvoke`) call — useful for
+background jobs and decoupled pipelines where work arrives as messages rather
+than synchronous HTTP requests. A graph may be registered on **both** surfaces.
+
+```python
+from azure_functions_langgraph import LangGraphApp
+
+app = LangGraphApp()
+
+# Queue trigger
+app.register_service_bus(
+    graph=graph,
+    name="jobs_agent",
+    connection="ServiceBusConnection",  # app-setting name
+    queue_name="langgraph-jobs",
+)
+
+# Or a topic subscription trigger
+app.register_service_bus(
+    graph=graph,
+    name="events_agent",
+    connection="ServiceBusConnection",
+    topic_name="events",
+    subscription_name="langgraph",
+)
+
+func_app = app.function_app
+```
+
+#### HTTP vs Service Bus
+
+| | HTTP (`register`) | Service Bus (`register_service_bus`) |
+|---|---|---|
+| Invocation | Synchronous `POST /api/graphs/{name}/invoke` | One graph run per queue/topic message |
+| Caller gets result | Yes — in the HTTP response | No — use `result_handler` to route output |
+| Delivery | At-most-once (caller retries) | At-least-once (binding abandons/retries) |
+| Backpressure | Caller-driven | Queue buffers + Functions scale-out |
+| Best for | Interactive request/response | Background jobs, decoupled pipelines |
+| Errors | Returned to caller | **Not swallowed** → message abandoned/retried |
+
+**Message mapping.** By default the message body is decoded as UTF-8 and parsed
+as JSON: a JSON object is passed through as the graph input verbatim; any other
+value (or non-JSON text) is wrapped as
+`{"messages": [{"role": "human", "content": <text>}]}`. Pass `input_mapper=...`
+to customize.
+
+**Thread state and locking.** Runs are **threadless** by default. Pass
+`thread_id_factory=...` to derive a checkpoint `thread_id` from a message; when
+it returns a value **and** the graph has a checkpointer, the app-level
+`thread_lock` guards the run so concurrent deliveries for the same logical
+thread do not mutate checkpoints concurrently. If the lock cannot be acquired a
+`ThreadContentionError` is raised so the binding abandons and retries.
+
+**Error handling and telemetry.** Graph exceptions are **not swallowed** — a
+failing run propagates so the message is retried / dead-lettered per your
+queue's policy. This package ships **no** Service Bus output binding; pass a
+`result_handler(result, msg)` to publish results. Message bodies and
+application-property values are **never** included in telemetry; runs carry a
+`trigger_type="service_bus"` correlation field so they are distinguishable from
+HTTP runs in your observer. See
+[`examples/service_bus_agent/`](examples/service_bus_agent/) for a full wiring.
+
+
 ### Per-graph auth
 
 Override app-level auth settings per graph:

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@
 | App Insights telemetry | [`observability_app_insights`](observability_app_insights/) | Ship run telemetry to Azure Application Insights with the built-in `LoggingRunObserver` — structured safe fields plus copy-pasteable KQL queries for run count, latency, error rate, and thread correlation. |
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
 | Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
+| Service Bus trigger | [`service_bus_agent`](service_bus_agent/) | Drive a graph from an Azure Service Bus **queue** message via `register_service_bus` — one `invoke` per message, exceptions not swallowed. |
 
 ## Conventions
 
@@ -58,3 +59,4 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 - **Observing run lifecycle (started/completed/failed/rejected)?** → `run_observer`
 - **Shipping run telemetry to Application Insights (KQL dashboards)?** → `observability_app_insights`
 - **Recovering orphaned run locks automatically?** → `maintenance_timer`
+- **Driving a graph from Service Bus messages (background jobs, decoupled pipelines)?** → `service_bus_agent`

--- a/examples/service_bus_agent/README.md
+++ b/examples/service_bus_agent/README.md
@@ -1,0 +1,89 @@
+# Service Bus Agent — Queue-Driven LangGraph
+
+This example drives a LangGraph graph from an **Azure Service Bus queue**
+message via `LangGraphApp.register_service_bus`, instead of (or in addition to)
+the HTTP endpoints. Each delivered message is mapped to a single graph
+`invoke` call.
+
+## When to use this example
+
+Use a Service Bus trigger when work arrives as **messages** rather than
+synchronous HTTP requests — background jobs, fan-out/fan-in pipelines, or
+decoupling a producer from graph execution with a durable buffer and
+at-least-once delivery. For request/response interactions where the caller
+waits for the result, use the HTTP `register(...)` surface instead.
+
+### HTTP vs Service Bus
+
+| | HTTP (`register`) | Service Bus (`register_service_bus`) |
+|---|---|---|
+| Invocation | Synchronous `POST /api/graphs/{name}/invoke` | One graph run per queue/topic message |
+| Caller gets result | Yes — in the HTTP response | No — use `result_handler` to route output |
+| Delivery | At-most-once (request fails, caller retries) | At-least-once (binding abandons/retries) |
+| Backpressure | Caller-driven | Queue buffers + Functions scale-out |
+| Best for | Interactive request/response | Background jobs, decoupled pipelines |
+| Errors | Returned to caller | **Not swallowed** → message abandoned/retried |
+
+A single graph may be registered on **both** surfaces.
+
+## Files
+
+- `graph.py` — the compiled graph (single `handle` node)
+- `function_app.py` — `register_service_bus` wiring for a queue trigger
+- `host.json`, `local.settings.json.example`, `requirements.txt`
+
+## App Settings
+
+| Setting | Description | Default |
+|---|---|---|
+| `ServiceBusConnection` | App-setting name holding the Service Bus connection string / FQNS | — |
+| `SERVICE_BUS_QUEUE_NAME` | Queue to bind the trigger to | `langgraph-jobs` |
+
+## Local development
+
+```bash
+cp local.settings.json.example local.settings.json
+# Fill in ServiceBusConnection with your namespace connection string
+
+pip install -r requirements.txt
+func start
+```
+
+Send a message to the `langgraph-jobs` queue (via the Azure portal, Service
+Bus Explorer, or `az servicebus`). The function maps the message body to the
+graph input and runs `invoke` once per message.
+
+## Message mapping
+
+By default (`default_message_mapper`), the message body is decoded as UTF-8 and
+parsed as JSON:
+
+- A JSON **object** is passed through as the graph input verbatim.
+- Any other value (or non-JSON text) is wrapped as
+  `{"messages": [{"role": "human", "content": <text>}]}`.
+
+Pass `input_mapper=...` to `register_service_bus` to customize this.
+
+## Thread state and locking
+
+By default runs are **threadless** — no `thread_id` is derived and no lock is
+taken. Pass `thread_id_factory=...` to derive a checkpoint `thread_id` from a
+message; when it returns a value **and** the graph has a checkpointer, the
+app-level `thread_lock` guards the run so concurrent deliveries for the same
+logical thread do not mutate checkpoints concurrently. If the lock cannot be
+acquired, a `ThreadContentionError` is raised so the binding abandons and
+retries the message.
+
+## Error handling
+
+Graph exceptions are **not swallowed** — a failing run propagates so the
+Service Bus binding abandons the message and it is retried / dead-lettered
+according to your queue's delivery policy. This package ships **no** Service
+Bus output binding; to publish a result, pass a `result_handler(result, msg)`.
+
+## Telemetry
+
+Message bodies and application-property values are **never** included in
+telemetry. Runs carry a `trigger_type="service_bus"` correlation field on the
+`RunContext` so Service Bus-driven runs are distinguishable from HTTP runs in
+your observer.

--- a/examples/service_bus_agent/function_app.py
+++ b/examples/service_bus_agent/function_app.py
@@ -1,0 +1,30 @@
+"""Service Bus agent — Azure Functions entry point.
+
+Drives a LangGraph graph from an Azure Service Bus queue message. Each
+delivery is mapped to a single ``invoke`` call. Graph exceptions are **not**
+swallowed, so a failing run lets the Service Bus binding abandon/retry the
+message according to your queue's delivery policy.
+
+Run from this directory:
+    func start
+"""
+
+from __future__ import annotations
+
+import os
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+
+langgraph_app = LangGraphApp()
+
+langgraph_app.register_service_bus(
+    graph=compiled_graph,
+    name="service_bus_agent",
+    connection="ServiceBusConnection",
+    queue_name=os.environ.get("SERVICE_BUS_QUEUE_NAME", "langgraph-jobs"),
+)
+
+
+app = langgraph_app.function_app

--- a/examples/service_bus_agent/graph.py
+++ b/examples/service_bus_agent/graph.py
@@ -1,0 +1,66 @@
+"""Service Bus agent example — LangGraph graph driven by a queue message.
+
+This example shows a minimal LangGraph ``StateGraph`` that is invoked once per
+Azure Service Bus **queue** message via ``LangGraphApp.register_service_bus``.
+
+Requirements::
+
+    pip install azure-functions-langgraph langgraph langchain-core
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+# ------------------------------------------------------------------
+# 1. Define state
+# ------------------------------------------------------------------
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+    reply: str
+
+
+# ------------------------------------------------------------------
+# 2. Define node functions
+# ------------------------------------------------------------------
+
+
+def handle(state: AgentState) -> dict[str, Any]:
+    """Single node — echoes the latest inbound message content."""
+    text = state["messages"][-1]["content"] if state["messages"] else ""
+    return {
+        "reply": f"processed: {text}",
+        "messages": state["messages"] + [{"role": "assistant", "content": f"processed: {text}"}],
+    }
+
+
+# ------------------------------------------------------------------
+# 3. Build the graph (using LangGraph API)
+# ------------------------------------------------------------------
+
+# NOTE: This block is guarded so the module can be imported without langgraph
+# installed (e.g. for testing the example structure).
+try:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(AgentState)
+    builder.add_node("handle", handle)
+    builder.add_edge(START, "handle")
+    builder.add_edge("handle", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError:
+    raise ImportError(
+        "langgraph is required for this example. "
+        "Install it with: pip install langgraph langchain-core"
+    )

--- a/examples/service_bus_agent/host.json
+++ b/examples/service_bus_agent/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/service_bus_agent/local.settings.json.example
+++ b/examples/service_bus_agent/local.settings.json.example
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "ServiceBusConnection": "Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=<policy>;SharedAccessKey=<key>",
+    "SERVICE_BUS_QUEUE_NAME": "langgraph-jobs"
+  }
+}

--- a/examples/service_bus_agent/requirements.txt
+++ b/examples/service_bus_agent/requirements.txt
@@ -1,0 +1,7 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-langgraph>=0.8,<0.9
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -38,6 +38,11 @@ if TYPE_CHECKING:
         StatefulGraph,
         StreamableGraph,
     )
+    from azure_functions_langgraph.triggers.service_bus import (
+        ServiceBusMessageLike,
+        ThreadContentionError,
+        default_message_mapper,
+    )
 
 
 # Maps a public attribute name to the (module_path, attribute) it lazily imports.
@@ -74,6 +79,19 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "RunTransport": ("azure_functions_langgraph.observability", "RunTransport"),
     "LoggingRunObserver": ("azure_functions_langgraph.observability", "LoggingRunObserver"),
     "OTelRunObserver": ("azure_functions_langgraph.observability_otel", "OTelRunObserver"),
+    # Triggers (issue #409)
+    "default_message_mapper": (
+        "azure_functions_langgraph.triggers.service_bus",
+        "default_message_mapper",
+    ),
+    "ServiceBusMessageLike": (
+        "azure_functions_langgraph.triggers.service_bus",
+        "ServiceBusMessageLike",
+    ),
+    "ThreadContentionError": (
+        "azure_functions_langgraph.triggers.service_bus",
+        "ThreadContentionError",
+    ),
 }
 
 # Symbols whose import failure means the optional runtime deps are missing;
@@ -142,4 +160,8 @@ __all__ = [
     "RunTransport",
     "LoggingRunObserver",
     "OTelRunObserver",
+    # Triggers
+    "default_message_mapper",
+    "ServiceBusMessageLike",
+    "ThreadContentionError",
 ]

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -228,6 +228,7 @@ class LangGraphApp:
     observer: Optional[RunObserver] = None
     route_prefix: str = _ROUTE_PREFIX  # metadata-only; must match host.json routePrefix
     _registrations: dict[str, _GraphRegistration] = field(default_factory=dict)
+    _sb_registrations: dict[str, Any] = field(default_factory=dict)
     _function_app: Optional[func.FunctionApp] = field(default=None, init=False, repr=False)
     _thread_store: Any = field(default=None, init=False, repr=False)
 
@@ -385,6 +386,115 @@ response_model: Optional Pydantic model class for response body
         # Reset cached function app so routes are re-generated
         self._function_app = None
 
+    def register_service_bus(
+        self,
+        graph: Any,
+        name: str,
+        *,
+        connection: str,
+        queue_name: Optional[str] = None,
+        topic_name: Optional[str] = None,
+        subscription_name: Optional[str] = None,
+        input_mapper: Optional[Callable[[Any], Any]] = None,
+        thread_id_factory: Optional[Callable[[Any], Optional[str]]] = None,
+        result_handler: Optional[Callable[[Any, Any], None]] = None,
+        async_mode: bool = False,
+        binding_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Register a compiled graph to be driven by an Azure Service Bus message.
+
+        Wires a Service Bus **queue** trigger (pass ``queue_name``) or a
+        **topic subscription** trigger (pass both ``topic_name`` and
+        ``subscription_name``) that maps each incoming message to a graph
+        ``invoke``/``ainvoke`` call. This is independent of the HTTP endpoints:
+        a graph may be registered on both surfaces.
+
+        Args:
+            graph: Any object satisfying :class:`~protocols.LangGraphLike`.
+            name: Unique trigger name (also the Azure Functions function name).
+            connection: App-setting name holding the Service Bus connection
+                string / fully-qualified namespace (passed to the binding).
+            queue_name: Queue to bind. Mutually exclusive with topic binding.
+            topic_name: Topic to bind (requires ``subscription_name``).
+            subscription_name: Subscription on ``topic_name``.
+            input_mapper: Maps a message to the graph ``input``. Defaults to
+                :func:`~triggers.service_bus.default_message_mapper`.
+            thread_id_factory: Optional factory deriving a checkpoint
+                ``thread_id`` from a message; ``None`` (default) keeps runs
+                threadless. When it returns a value **and** the graph has a
+                checkpointer, the app-level ``thread_lock`` guards the run.
+            result_handler: Optional sink called with ``(result, message)``
+                after a successful run. Its exceptions propagate and fail the
+                message; this package ships no Service Bus output binding.
+            async_mode: Route through an async handler that awaits
+                ``ainvoke``. Required for async-only graphs.
+            binding_kwargs: Extra keyword arguments forwarded verbatim to the
+                underlying Azure Functions trigger decorator (escape hatch for
+                sessions, cardinality, access rights, etc.).
+
+        Raises:
+            TypeError: If *graph* does not satisfy the required protocol, or if
+                ``async_mode=True`` but the graph has no ``ainvoke``.
+            ValueError: If *name* is already registered, invalid, or the
+                queue/topic binding arguments are not a valid combination.
+        """
+        from azure_functions_langgraph.triggers.service_bus import (
+            _ServiceBusRegistration,
+            default_message_mapper,
+        )
+
+        has_sync_invoke = isinstance(graph, InvocableGraph)
+        has_async_invoke = isinstance(graph, AsyncInvocableGraph)
+        if async_mode and not has_async_invoke:
+            raise TypeError(
+                "async_mode=True requires an ainvoke() method. "
+                f"Got {type(graph).__name__}"
+            )
+        if not has_sync_invoke and not has_async_invoke:
+            raise TypeError(
+                "Graph must have an invoke() or ainvoke() method. "
+                f"Got {type(graph).__name__}"
+            )
+        name_err = validate_graph_name(name)
+        if name_err:
+            raise ValueError(name_err)
+        if name in self._sb_registrations:
+            raise ValueError(f"Service Bus trigger {name!r} is already registered")
+
+        is_queue = queue_name is not None
+        is_topic = topic_name is not None or subscription_name is not None
+        if is_queue and is_topic:
+            raise ValueError(
+                "Provide either queue_name or (topic_name + subscription_name), "
+                "not both"
+            )
+        if not is_queue and not is_topic:
+            raise ValueError(
+                "Provide queue_name for a queue trigger, or both topic_name and "
+                "subscription_name for a topic-subscription trigger"
+            )
+        if is_topic and (topic_name is None or subscription_name is None):
+            raise ValueError(
+                "A topic trigger requires both topic_name and subscription_name"
+            )
+
+        effective_async = async_mode or not has_sync_invoke
+        self._sb_registrations[name] = _ServiceBusRegistration(
+            graph=graph,
+            name=name,
+            connection=connection,
+            queue_name=queue_name,
+            topic_name=topic_name,
+            subscription_name=subscription_name,
+            input_mapper=input_mapper or default_message_mapper,
+            thread_id_factory=thread_id_factory,
+            result_handler=result_handler,
+            async_mode=effective_async,
+            binding_kwargs=dict(binding_kwargs or {}),
+        )
+        # Reset cached function app so routes are re-generated.
+        self._function_app = None
+
     @property
     def function_app(self) -> func.FunctionApp:
         """Return an ``azure.functions.FunctionApp`` with all routes registered."""
@@ -499,6 +609,11 @@ response_model: Optional Pydantic model class for response body
                     handler_impl=self._handle_state,
                 )
 
+        # Service Bus trigger routes (issue #409)
+        for sb_reg in self._sb_registrations.values():
+            self._register_service_bus_trigger(app, sb_reg)
+
+        # Platform API compatibility routes
         # Platform API compatibility routes
         if self.platform_compat:
             from azure_functions_langgraph.platform.routes import (
@@ -519,6 +634,71 @@ response_model: Optional Pydantic model class for response body
             register_platform_routes(app, deps)
 
         return app
+
+    def _register_service_bus_trigger(
+        self,
+        app: func.FunctionApp,
+        sb_reg: Any,
+    ) -> None:
+        """Wire one Service Bus queue/topic trigger to a graph invocation.
+
+        Builds a queue or topic-subscription trigger whose handler maps each
+        message through the registration and drives the graph. Async
+        registrations get a real ``async def`` handler that awaits the graph;
+        sync registrations get a plain handler. Graph and result-handler
+        exceptions propagate so the Service Bus runtime abandons / dead-letters
+        the message per its retry policy.
+        """
+        from azure_functions_langgraph.triggers.service_bus import (
+            process_service_bus_message,
+            process_service_bus_message_async,
+        )
+
+        thread_lock = self.thread_lock
+        if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
+            raise RuntimeError("thread_lock is None; __post_init__ did not run")
+        observer = self.observer or NoOpRunObserver()
+        captured = sb_reg
+        fn_name = f"aflg_sb_{sb_reg.name}"
+
+        if sb_reg.is_topic:
+            trigger = app.service_bus_topic_trigger(
+                arg_name="msg",
+                connection=sb_reg.connection,
+                topic_name=sb_reg.topic_name,
+                subscription_name=sb_reg.subscription_name,
+                **sb_reg.binding_kwargs,
+            )
+        else:
+            trigger = app.service_bus_queue_trigger(
+                arg_name="msg",
+                connection=sb_reg.connection,
+                queue_name=sb_reg.queue_name,
+                **sb_reg.binding_kwargs,
+            )
+
+        if sb_reg.async_mode:
+
+            async def sb_async_handler(msg: Any) -> None:
+                await process_service_bus_message_async(
+                    captured,
+                    msg,
+                    thread_lock=thread_lock,
+                    observer=observer,
+                )
+
+            app.function_name(name=fn_name)(trigger(sb_async_handler))
+        else:
+
+            def sb_handler(msg: Any) -> None:
+                process_service_bus_message(
+                    captured,
+                    msg,
+                    thread_lock=thread_lock,
+                    observer=observer,
+                )
+
+            app.function_name(name=fn_name)(trigger(sb_handler))
 
     @staticmethod
     def _has_stream_route(reg: _GraphRegistration) -> bool:

--- a/src/azure_functions_langgraph/observability.py
+++ b/src/azure_functions_langgraph/observability.py
@@ -68,6 +68,11 @@ class RunContext:
     transport: RunTransport = "buffered"
     has_checkpointer: bool | None = None
     lock_backend: str | None = None
+    # Generic trigger classification (issue #409). ``None`` for HTTP invoke/stream
+    # runs; set to e.g. ``"service_bus"`` for event-driven trigger adapters so
+    # exporters can distinguish transport-agnostic run sources. Carries no
+    # payload — only a stable, low-cardinality trigger label.
+    trigger_type: str | None = None
 
 
 
@@ -146,6 +151,7 @@ def new_run_context(
     transport: RunTransport = "buffered",
     has_checkpointer: bool | None = None,
     lock_backend: str | None = None,
+    trigger_type: str | None = None,
 ) -> RunContext:
     """Create a fresh :class:`RunContext` with a unique run id and start time.
 
@@ -167,6 +173,7 @@ def new_run_context(
         transport=transport,
         has_checkpointer=has_checkpointer,
         lock_backend=lock_backend,
+        trigger_type=trigger_type,
     )
 
 
@@ -212,6 +219,7 @@ def _safe_fields(ctx: RunContext, **extra: object) -> dict[str, object]:
         "transport": ctx.transport,
         "has_checkpointer": ctx.has_checkpointer,
         "lock_backend": ctx.lock_backend,
+        "trigger_type": ctx.trigger_type,
         "duration_ms": _duration_ms(ctx),
     }
     fields.update(extra)

--- a/src/azure_functions_langgraph/observability_otel.py
+++ b/src/azure_functions_langgraph/observability_otel.py
@@ -68,6 +68,7 @@ def _safe_attributes(ctx: RunContext) -> dict[str, AttributeValue]:
         f"{_ATTR_PREFIX}.transport": ctx.transport,
         f"{_ATTR_PREFIX}.has_checkpointer": ctx.has_checkpointer,
         f"{_ATTR_PREFIX}.lock_backend": ctx.lock_backend,
+        f"{_ATTR_PREFIX}.trigger_type": ctx.trigger_type,
     }
     return {key: value for key, value in raw.items() if value is not None}
 

--- a/src/azure_functions_langgraph/triggers/__init__.py
+++ b/src/azure_functions_langgraph/triggers/__init__.py
@@ -1,0 +1,30 @@
+"""Event-driven trigger adapters for LangGraph graphs.
+
+Currently ships the Azure Service Bus trigger adapter (issue #409). Trigger
+adapters let a compiled graph be driven by a broker message rather than an HTTP
+request, while reusing the package's thread-lock and observability contracts.
+"""
+
+from __future__ import annotations
+
+from azure_functions_langgraph.triggers.service_bus import (
+    InputMapper,
+    ResultHandler,
+    ServiceBusMessageLike,
+    ThreadContentionError,
+    ThreadIdFactory,
+    default_message_mapper,
+    process_service_bus_message,
+    process_service_bus_message_async,
+)
+
+__all__ = [
+    "InputMapper",
+    "ResultHandler",
+    "ServiceBusMessageLike",
+    "ThreadContentionError",
+    "ThreadIdFactory",
+    "default_message_mapper",
+    "process_service_bus_message",
+    "process_service_bus_message_async",
+]

--- a/src/azure_functions_langgraph/triggers/service_bus.py
+++ b/src/azure_functions_langgraph/triggers/service_bus.py
@@ -1,0 +1,274 @@
+"""Azure Service Bus trigger adapter for LangGraph graphs (issue #409).
+
+This module lets a compiled LangGraph graph be driven by an **Azure Service Bus**
+queue or topic-subscription message instead of (or in addition to) the native
+HTTP endpoints, without hand-writing the trigger glue for each project.
+
+Design boundaries (issue #409):
+
+- **No exactly-once semantics.** Service Bus delivery is at-least-once; a graph
+  invocation may run more than once for the same logical message (redelivery
+  after lock expiry, failover, etc.). Graphs that mutate external state must be
+  idempotent. This adapter does **not** add dedup.
+- **A message is not implicitly a thread.** By default runs are threadless; the
+  operator opts into checkpointed conversations by supplying a
+  ``thread_id_factory``. When a ``thread_id`` is derived *and* the graph has a
+  checkpointer, the adapter reuses the package's existing
+  :class:`~azure_functions_langgraph.locks.base.ThreadLock` so concurrent
+  deliveries for the same logical thread cannot mutate checkpoints
+  concurrently — a redelivery that collides with an in-flight run raises so the
+  broker retries.
+- **Graph exceptions are never swallowed.** A failed graph run propagates so the
+  Service Bus runtime abandons/dead-letters the message per its retry policy.
+- **No telemetry payload leakage.** Only correlation identifiers and timing are
+  observed; message bodies and application-property values are never recorded.
+- **No output publishing.** Emitting results back to Service Bus (or elsewhere)
+  is left to a caller-supplied ``result_handler``; this adapter ships no output
+  binding.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
+
+from azure_functions_langgraph.locks import ThreadLock
+from azure_functions_langgraph.observability import (
+    NOOP_OBSERVER,
+    RunObserver,
+    finish_context,
+    new_run_context,
+    safe_observer_call,
+)
+
+# The generic trigger label stamped onto every RunContext this adapter emits, so
+# exporters can distinguish Service Bus runs from HTTP invoke/stream runs.
+TRIGGER_TYPE = "service_bus"
+
+
+@runtime_checkable
+class ServiceBusMessageLike(Protocol):
+    """Structural subset of :class:`azure.functions.ServiceBusMessage`.
+
+    Only the members this adapter reads are declared, so tests (and alternative
+    runtimes) can supply a lightweight fake without depending on the concrete
+    Azure Functions message type. Every attribute mirrors the corresponding
+    ``azure.functions.ServiceBusMessage`` member.
+    """
+
+    def get_body(self) -> bytes:
+        """Return the raw message body as bytes."""
+        ...
+
+    @property
+    def message_id(self) -> Optional[str]:
+        """Broker-assigned unique message identifier, if present."""
+        ...
+
+
+# Mapper turning a raw Service Bus message into the ``input`` passed to the
+# graph. Kept as a plain callable so operators can supply their own.
+InputMapper = Callable[[ServiceBusMessageLike], Any]
+
+# Optional factory deriving a ``thread_id`` (checkpointed conversation key) from
+# a message. Returning ``None`` keeps the run threadless.
+ThreadIdFactory = Callable[[ServiceBusMessageLike], Optional[str]]
+
+# Optional sink invoked with ``(result, message)`` after a successful run. Its
+# exceptions propagate (failing the message) so downstream delivery guarantees
+# are the operator's to reason about.
+ResultHandler = Callable[[Any, ServiceBusMessageLike], None]
+
+
+def _decode_body(msg: ServiceBusMessageLike) -> str:
+    """Decode a message body to text, tolerating invalid UTF-8 bytes."""
+    return msg.get_body().decode("utf-8", errors="replace")
+
+
+def default_message_mapper(msg: ServiceBusMessageLike) -> dict[str, Any]:
+    """Map a Service Bus message body to a default LangGraph ``input`` dict.
+
+    The body is decoded as UTF-8 (invalid bytes are replaced, never raised) and
+    parsed as JSON:
+
+    - a JSON **object** is passed straight through as the graph input;
+    - any other JSON value, or non-JSON text, is wrapped as a single human
+      message: ``{"messages": [{"role": "human", "content": <text>}]}``.
+
+    This keeps the zero-config path useful for both structured producers (that
+    already emit a graph-shaped payload) and plain-text producers, while letting
+    operators override with a custom ``input_mapper`` when neither shape fits.
+    """
+    text = _decode_body(msg)
+    try:
+        parsed = json.loads(text)
+    except (ValueError, TypeError):
+        parsed = None
+    if isinstance(parsed, dict):
+        return parsed
+    return {"messages": [{"role": "human", "content": text}]}
+
+
+@dataclass
+class _ServiceBusRegistration:
+    """Internal registration record for a Service-Bus-triggered graph.
+
+    Exactly one of ``queue_name`` or (``topic_name`` + ``subscription_name``)
+    is set; :func:`~azure_functions_langgraph.app.LangGraphApp.register_service_bus`
+    validates the combination before constructing this record.
+    """
+
+    graph: Any
+    name: str
+    connection: str
+    queue_name: Optional[str] = None
+    topic_name: Optional[str] = None
+    subscription_name: Optional[str] = None
+    input_mapper: InputMapper = default_message_mapper
+    thread_id_factory: Optional[ThreadIdFactory] = None
+    result_handler: Optional[ResultHandler] = None
+    async_mode: bool = False
+    binding_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_topic(self) -> bool:
+        """Whether this registration binds a topic subscription (vs a queue)."""
+        return self.topic_name is not None
+
+
+def _has_checkpointer(graph: Any) -> bool:
+    """Whether a compiled graph has a checkpointer attached."""
+    return getattr(graph, "checkpointer", None) is not None
+
+
+class ThreadContentionError(RuntimeError):
+    """Raised when a redelivery collides with an in-flight run for a thread.
+
+    Propagated (never swallowed) so the Service Bus runtime abandons the message
+    and the broker retries it after the current holder releases the lock. This
+    preserves single-writer checkpoint safety without dropping the message.
+    """
+
+
+
+
+def process_service_bus_message(
+    reg: _ServiceBusRegistration,
+    msg: ServiceBusMessageLike,
+    *,
+    thread_lock: ThreadLock,
+    observer: RunObserver = NOOP_OBSERVER,
+) -> Any:
+    """Drive a graph synchronously from one Service Bus message.
+
+    Emits the observer lifecycle (started → completed/failed) around the graph
+    ``invoke``. When a ``thread_id`` is derived and the graph is checkpointed, a
+    non-blocking thread lock guards the run; contention raises
+    :class:`ThreadContentionError` so the broker retries. Graph exceptions are
+    re-raised unchanged (never swallowed). A supplied ``result_handler`` runs
+    only on success, **outside** the observed block, so its failure does not
+    emit a second terminal observer event — but it still propagates and fails
+    the message.
+
+    Returns the graph result so alternative drivers can post-process it.
+    """
+    graph_input = reg.input_mapper(msg)
+    thread_id = reg.thread_id_factory(msg) if reg.thread_id_factory is not None else None
+    ctx = new_run_context(
+        reg.name,
+        "invoke",
+        thread_id=thread_id,
+        invocation_id=msg.message_id,
+        has_checkpointer=_has_checkpointer(reg.graph),
+        lock_backend=type(thread_lock).__name__,
+        trigger_type=TRIGGER_TYPE,
+    )
+
+    lock_token: str | None = None
+    use_lock = bool(thread_id) and _has_checkpointer(reg.graph)
+    if use_lock and thread_id is not None:
+        lock_token = thread_lock.acquire(reg.name, thread_id)
+        if not lock_token:
+            raise ThreadContentionError(
+                f"Thread {thread_id!r} for graph {reg.name!r} is currently in use; "
+                "message will be retried by the broker"
+            )
+
+    config = {"configurable": {"thread_id": thread_id}} if thread_id else None
+    safe_observer_call(observer, "on_run_started", ctx)
+    try:
+        if config is not None:
+            result = reg.graph.invoke(graph_input, config=config)
+        else:
+            result = reg.graph.invoke(graph_input)
+    except BaseException as exc:
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), exc)
+        raise
+    else:
+        safe_observer_call(observer, "on_run_completed", finish_context(ctx))
+    finally:
+        if lock_token is not None and thread_id is not None:
+            thread_lock.release(reg.name, thread_id, lock_token)
+
+    if reg.result_handler is not None:
+        reg.result_handler(result, msg)
+    return result
+
+
+async def process_service_bus_message_async(
+    reg: _ServiceBusRegistration,
+    msg: ServiceBusMessageLike,
+    *,
+    thread_lock: ThreadLock,
+    observer: RunObserver = NOOP_OBSERVER,
+) -> Any:
+    """Async counterpart of :func:`process_service_bus_message`.
+
+    Awaits ``reg.graph.ainvoke`` and offloads the synchronous thread-lock calls
+    to a worker thread so a blocking lock backend never stalls the event loop.
+    All ordering, contention, and result-handler semantics match the sync path.
+    """
+    import asyncio
+
+    graph_input = reg.input_mapper(msg)
+    thread_id = reg.thread_id_factory(msg) if reg.thread_id_factory is not None else None
+    ctx = new_run_context(
+        reg.name,
+        "invoke",
+        thread_id=thread_id,
+        invocation_id=msg.message_id,
+        has_checkpointer=_has_checkpointer(reg.graph),
+        lock_backend=type(thread_lock).__name__,
+        trigger_type=TRIGGER_TYPE,
+    )
+
+    lock_token: str | None = None
+    use_lock = bool(thread_id) and _has_checkpointer(reg.graph)
+    if use_lock and thread_id is not None:
+        lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
+        if not lock_token:
+            raise ThreadContentionError(
+                f"Thread {thread_id!r} for graph {reg.name!r} is currently in use; "
+                "message will be retried by the broker"
+            )
+
+    config = {"configurable": {"thread_id": thread_id}} if thread_id else None
+    safe_observer_call(observer, "on_run_started", ctx)
+    try:
+        if config is not None:
+            result = await reg.graph.ainvoke(graph_input, config=config)
+        else:
+            result = await reg.graph.ainvoke(graph_input)
+    except BaseException as exc:
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), exc)
+        raise
+    else:
+        safe_observer_call(observer, "on_run_completed", finish_context(ctx))
+    finally:
+        if lock_token is not None and thread_id is not None:
+            await asyncio.to_thread(thread_lock.release, reg.name, thread_id, lock_token)
+
+    if reg.result_handler is not None:
+        reg.result_handler(result, msg)
+    return result

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -25,6 +25,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("run_observer", "compiled_graph"),
     ("observability_app_insights", "compiled_graph"),
     ("run_observer_otel", "compiled_graph"),
+    ("service_bus_agent", "compiled_graph"),
 )
 
 
@@ -81,6 +82,7 @@ EXAMPLE_DIRS = (
     "run_observer",
     "observability_app_insights",
     "run_observer_otel",
+    "service_bus_agent",
 )
 
 

--- a/tests/test_observability_otel.py
+++ b/tests/test_observability_otel.py
@@ -187,6 +187,7 @@ class TestSafeAttributes:
             "transport",
             "has_checkpointer",
             "lock_backend",
+            "trigger_type",
         }
         for key in attrs:
             assert key.split(".", 1)[1] in allowed_suffixes

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -52,6 +52,11 @@ def test_all_exports() -> None:
     assert "OTelRunObserver" in azure_functions_langgraph.__all__
     assert "RunTransport" in azure_functions_langgraph.__all__
 
+    # Service Bus trigger public surface
+    assert "default_message_mapper" in azure_functions_langgraph.__all__
+    assert "ServiceBusMessageLike" in azure_functions_langgraph.__all__
+    assert "ThreadContentionError" in azure_functions_langgraph.__all__
+
 
 def test_contracts_importable() -> None:
     from azure_functions_langgraph.contracts import (

--- a/tests/test_service_bus.py
+++ b/tests/test_service_bus.py
@@ -1,0 +1,418 @@
+"""Deterministic tests for the Azure Service Bus trigger adapter (issue #409)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import azure.functions as func
+import pytest
+
+from azure_functions_langgraph.app import LangGraphApp
+from azure_functions_langgraph.locks import InProcessThreadLock
+from azure_functions_langgraph.observability import RunContext
+from azure_functions_langgraph.triggers.service_bus import (
+    ThreadContentionError,
+    _ServiceBusRegistration,
+    default_message_mapper,
+    process_service_bus_message,
+    process_service_bus_message_async,
+)
+
+
+class FakeServiceBusMessage:
+    """Deterministic stand-in for ``azure.functions.ServiceBusMessage``."""
+
+    def __init__(self, body: bytes, *, message_id: Optional[str] = "msg-1") -> None:
+        self._body = body
+        self.message_id = message_id
+
+    def get_body(self) -> bytes:
+        return self._body
+
+
+class RecordingObserver:
+    """Observer capturing lifecycle events for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, RunContext]] = []
+
+    def on_run_started(self, ctx: RunContext) -> None:
+        self.events.append(("started", ctx))
+
+    def on_run_completed(self, ctx: RunContext) -> None:
+        self.events.append(("completed", ctx))
+
+    def on_run_failed(self, ctx: RunContext, exc: BaseException) -> None:
+        self.events.append(("failed", ctx))
+
+    def on_run_rejected(self, ctx: RunContext, reason: str) -> None:  # pragma: no cover
+        self.events.append(("rejected", ctx))
+
+
+class RecordingGraph:
+    """Graph capturing the input/config it was invoked with."""
+
+    def __init__(self, *, checkpointer: Any = None, result: Any = None) -> None:
+        self.checkpointer = checkpointer
+        self._result = result if result is not None else {"ok": True}
+        self.calls: list[tuple[Any, Any]] = []
+
+    def invoke(self, input: Any, config: Any = None) -> Any:
+        self.calls.append((input, config))
+        return self._result
+
+    def stream(self, input: Any, config: Any = None, stream_mode: str = "values") -> Any:
+        yield {"chunk": 1}
+
+
+class AsyncRecordingGraph:
+    """Async graph capturing invocation args."""
+
+    def __init__(self, *, checkpointer: Any = None, result: Any = None) -> None:
+        self.checkpointer = checkpointer
+        self._result = result if result is not None else {"ok": True}
+        self.calls: list[tuple[Any, Any]] = []
+
+    async def ainvoke(self, input: Any, config: Any = None) -> Any:
+        self.calls.append((input, config))
+        return self._result
+
+    async def astream(self, input: Any, config: Any = None, stream_mode: str = "values") -> Any:
+        yield {"chunk": 1}
+
+
+class FailingGraph:
+    checkpointer = None
+
+    def invoke(self, input: Any, config: Any = None) -> Any:
+        raise RuntimeError("boom")
+
+
+def _reg(graph: Any, **kwargs: Any) -> _ServiceBusRegistration:
+    kwargs.setdefault("connection", "SB_CONN")
+    kwargs.setdefault("queue_name", "q")
+    return _ServiceBusRegistration(graph=graph, name="agent", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# default_message_mapper
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultMessageMapper:
+    def test_json_object_passthrough(self) -> None:
+        msg = FakeServiceBusMessage(b'{"messages": [{"role": "human", "content": "hi"}]}')
+        assert default_message_mapper(msg) == {"messages": [{"role": "human", "content": "hi"}]}
+
+    def test_json_non_object_is_wrapped(self) -> None:
+        msg = FakeServiceBusMessage(b'["a", "b"]')
+        assert default_message_mapper(msg) == {
+            "messages": [{"role": "human", "content": '["a", "b"]'}]
+        }
+
+    def test_plain_text_is_wrapped(self) -> None:
+        msg = FakeServiceBusMessage(b"hello world")
+        assert default_message_mapper(msg) == {
+            "messages": [{"role": "human", "content": "hello world"}]
+        }
+
+    def test_invalid_utf8_does_not_raise(self) -> None:
+        msg = FakeServiceBusMessage(b"\xff\xfe bad bytes")
+        result = default_message_mapper(msg)
+        assert result["messages"][0]["role"] == "human"
+
+
+# ---------------------------------------------------------------------------
+# process_service_bus_message (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessSync:
+    def test_threadless_success_no_config(self) -> None:
+        graph = RecordingGraph()
+        observer = RecordingObserver()
+        lock = InProcessThreadLock()
+        result = process_service_bus_message(
+            _reg(graph), FakeServiceBusMessage(b"hi"), thread_lock=lock, observer=observer
+        )
+        assert result == {"ok": True}
+        # No thread_id => no config forwarded.
+        assert graph.calls[0][1] is None
+        assert [e[0] for e in observer.events] == ["started", "completed"]
+        ctx = observer.events[0][1]
+        assert ctx.trigger_type == "service_bus"
+        assert ctx.invocation_id == "msg-1"
+        assert ctx.thread_id is None
+
+    def test_custom_input_mapper(self) -> None:
+        graph = RecordingGraph()
+        reg = _reg(graph, input_mapper=lambda m: {"custom": m.get_body().decode()})
+        process_service_bus_message(
+            reg, FakeServiceBusMessage(b"payload"), thread_lock=InProcessThreadLock()
+        )
+        assert graph.calls[0][0] == {"custom": "payload"}
+
+    def test_thread_id_with_checkpointer_forwards_config_and_locks(self) -> None:
+        graph = RecordingGraph(checkpointer=MagicMock())
+        lock = InProcessThreadLock()
+        acquire_spy = MagicMock(wraps=lock.acquire)
+        release_spy = MagicMock(wraps=lock.release)
+        lock.acquire = acquire_spy  # type: ignore[method-assign]
+        lock.release = release_spy  # type: ignore[method-assign]
+        reg = _reg(graph, thread_id_factory=lambda m: "thread-A")
+        process_service_bus_message(reg, FakeServiceBusMessage(b"hi"), thread_lock=lock)
+        assert graph.calls[0][1] == {"configurable": {"thread_id": "thread-A"}}
+        acquire_spy.assert_called_once_with("agent", "thread-A")
+        release_spy.assert_called_once()
+
+    def test_thread_id_without_checkpointer_does_not_lock(self) -> None:
+        graph = RecordingGraph(checkpointer=None)
+        lock = InProcessThreadLock()
+        acquire_spy = MagicMock(wraps=lock.acquire)
+        lock.acquire = acquire_spy  # type: ignore[method-assign]
+        reg = _reg(graph, thread_id_factory=lambda m: "thread-A")
+        process_service_bus_message(reg, FakeServiceBusMessage(b"hi"), thread_lock=lock)
+        acquire_spy.assert_not_called()
+        # thread_id still forwarded via config for a non-checkpointed graph.
+        assert graph.calls[0][1] == {"configurable": {"thread_id": "thread-A"}}
+
+    def test_lock_contention_raises(self) -> None:
+        graph = RecordingGraph(checkpointer=MagicMock())
+        lock = InProcessThreadLock()
+        held = lock.acquire("agent", "thread-A")
+        assert held is not None
+        reg = _reg(graph, thread_id_factory=lambda m: "thread-A")
+        with pytest.raises(ThreadContentionError):
+            process_service_bus_message(reg, FakeServiceBusMessage(b"hi"), thread_lock=lock)
+        # Graph never ran.
+        assert graph.calls == []
+
+    def test_graph_failure_reraised_and_observed(self) -> None:
+        observer = RecordingObserver()
+        reg = _reg(FailingGraph())
+        with pytest.raises(RuntimeError, match="boom"):
+            process_service_bus_message(
+                reg,
+                FakeServiceBusMessage(b"hi"),
+                thread_lock=InProcessThreadLock(),
+                observer=observer,
+            )
+        assert [e[0] for e in observer.events] == ["started", "failed"]
+
+    def test_failure_releases_lock(self) -> None:
+        lock = InProcessThreadLock()
+
+        class FailingCheckpointedGraph:
+            checkpointer = MagicMock()
+
+            def invoke(self, input: Any, config: Any = None) -> Any:
+                raise RuntimeError("boom")
+
+        reg = _reg(FailingCheckpointedGraph(), thread_id_factory=lambda m: "thread-A")
+        with pytest.raises(RuntimeError):
+            process_service_bus_message(reg, FakeServiceBusMessage(b"hi"), thread_lock=lock)
+        # Lock is free again — re-acquire succeeds.
+        assert lock.acquire("agent", "thread-A") is not None
+
+    def test_result_handler_called_on_success(self) -> None:
+        seen: list[tuple[Any, Any]] = []
+        graph = RecordingGraph(result={"answer": 42})
+        reg = _reg(graph, result_handler=lambda r, m: seen.append((r, m.message_id)))
+        process_service_bus_message(
+            reg, FakeServiceBusMessage(b"hi"), thread_lock=InProcessThreadLock()
+        )
+        assert seen == [({"answer": 42}, "msg-1")]
+
+    def test_result_handler_failure_propagates_without_second_terminal(self) -> None:
+        observer = RecordingObserver()
+
+        def boom(result: Any, msg: Any) -> None:
+            raise ValueError("handler failed")
+
+        reg = _reg(RecordingGraph(), result_handler=boom)
+        with pytest.raises(ValueError, match="handler failed"):
+            process_service_bus_message(
+                reg,
+                FakeServiceBusMessage(b"hi"),
+                thread_lock=InProcessThreadLock(),
+                observer=observer,
+            )
+        # Run already completed before the handler ran — exactly one terminal event.
+        assert [e[0] for e in observer.events] == ["started", "completed"]
+
+
+# ---------------------------------------------------------------------------
+# process_service_bus_message_async
+# ---------------------------------------------------------------------------
+
+
+class TestProcessAsync:
+    def test_async_success(self) -> None:
+        graph = AsyncRecordingGraph()
+        observer = RecordingObserver()
+        reg = _reg(graph)
+        result = asyncio.run(
+            process_service_bus_message_async(
+                reg,
+                FakeServiceBusMessage(b"hi"),
+                thread_lock=InProcessThreadLock(),
+                observer=observer,
+            )
+        )
+        assert result == {"ok": True}
+        assert graph.calls[0][1] is None
+        assert [e[0] for e in observer.events] == ["started", "completed"]
+
+    def test_async_thread_id_locks_and_forwards_config(self) -> None:
+        graph = AsyncRecordingGraph(checkpointer=MagicMock())
+        lock = InProcessThreadLock()
+        reg = _reg(graph, thread_id_factory=lambda m: "t")
+        asyncio.run(
+            process_service_bus_message_async(reg, FakeServiceBusMessage(b"hi"), thread_lock=lock)
+        )
+        assert graph.calls[0][1] == {"configurable": {"thread_id": "t"}}
+        # Lock released — re-acquire works.
+        assert lock.acquire("agent", "t") is not None
+
+    def test_async_contention_raises(self) -> None:
+        graph = AsyncRecordingGraph(checkpointer=MagicMock())
+        lock = InProcessThreadLock()
+        assert lock.acquire("agent", "t") is not None
+        reg = _reg(graph, thread_id_factory=lambda m: "t")
+        with pytest.raises(ThreadContentionError):
+            asyncio.run(
+                process_service_bus_message_async(
+                    reg, FakeServiceBusMessage(b"hi"), thread_lock=lock
+                )
+            )
+
+    def test_async_failure_reraised(self) -> None:
+        class AsyncFailingGraph:
+            checkpointer = None
+
+            async def ainvoke(self, input: Any, config: Any = None) -> Any:
+                raise RuntimeError("boom")
+
+        observer = RecordingObserver()
+        reg = _reg(AsyncFailingGraph())
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(
+                process_service_bus_message_async(
+                    reg,
+                    FakeServiceBusMessage(b"hi"),
+                    thread_lock=InProcessThreadLock(),
+                    observer=observer,
+                )
+            )
+        assert [e[0] for e in observer.events] == ["started", "failed"]
+
+    def test_async_result_handler(self) -> None:
+        seen: list[Any] = []
+        reg = _reg(AsyncRecordingGraph(result={"a": 1}), result_handler=lambda r, m: seen.append(r))
+        asyncio.run(
+            process_service_bus_message_async(
+                reg, FakeServiceBusMessage(b"hi"), thread_lock=InProcessThreadLock()
+            )
+        )
+        assert seen == [{"a": 1}]
+
+
+# ---------------------------------------------------------------------------
+# LangGraphApp.register_service_bus
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterServiceBus:
+    def _app(self) -> LangGraphApp:
+        return LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+
+    def test_queue_registration_builds_function_app(self) -> None:
+        app = self._app()
+        app.register_service_bus(RecordingGraph(), "sb_agent", connection="SB", queue_name="q")
+        # Building the function app wires the trigger without raising.
+        assert app.function_app is not None
+        assert "sb_agent" in app._sb_registrations
+
+    def test_topic_registration_builds_function_app(self) -> None:
+        app = self._app()
+        app.register_service_bus(
+            RecordingGraph(),
+            "sb_topic",
+            connection="SB",
+            topic_name="t",
+            subscription_name="s",
+        )
+        assert app.function_app is not None
+        assert app._sb_registrations["sb_topic"].is_topic is True
+
+    def test_async_graph_auto_detected(self) -> None:
+        app = self._app()
+        app.register_service_bus(AsyncRecordingGraph(), "sb_async", connection="SB", queue_name="q")
+        assert app._sb_registrations["sb_async"].async_mode is True
+        assert app.function_app is not None
+
+    def test_explicit_async_mode(self) -> None:
+        app = self._app()
+        app.register_service_bus(
+            AsyncRecordingGraph(), "sb_a", connection="SB", queue_name="q", async_mode=True
+        )
+        assert app._sb_registrations["sb_a"].async_mode is True
+
+    def test_binding_kwargs_forwarded(self) -> None:
+        app = self._app()
+        app.register_service_bus(
+            RecordingGraph(),
+            "sb_b",
+            connection="SB",
+            queue_name="q",
+            binding_kwargs={"is_sessions_enabled": True},
+        )
+        assert app.function_app is not None
+
+    def test_queue_and_topic_both_rejected(self) -> None:
+        app = self._app()
+        with pytest.raises(ValueError, match="not both"):
+            app.register_service_bus(
+                RecordingGraph(), "x", connection="SB", queue_name="q", topic_name="t"
+            )
+
+    def test_neither_queue_nor_topic_rejected(self) -> None:
+        app = self._app()
+        with pytest.raises(ValueError, match="Provide queue_name"):
+            app.register_service_bus(RecordingGraph(), "x", connection="SB")
+
+    def test_topic_without_subscription_rejected(self) -> None:
+        app = self._app()
+        with pytest.raises(ValueError, match="requires both"):
+            app.register_service_bus(RecordingGraph(), "x", connection="SB", topic_name="t")
+
+    def test_duplicate_name_rejected(self) -> None:
+        app = self._app()
+        app.register_service_bus(RecordingGraph(), "dup", connection="SB", queue_name="q")
+        with pytest.raises(ValueError, match="already registered"):
+            app.register_service_bus(RecordingGraph(), "dup", connection="SB", queue_name="q2")
+
+    def test_invalid_name_rejected(self) -> None:
+        app = self._app()
+        with pytest.raises(ValueError):
+            app.register_service_bus(RecordingGraph(), "bad name!", connection="SB", queue_name="q")
+
+    def test_async_mode_without_ainvoke_rejected(self) -> None:
+        app = self._app()
+        with pytest.raises(TypeError, match="ainvoke"):
+            app.register_service_bus(
+                RecordingGraph(), "x", connection="SB", queue_name="q", async_mode=True
+            )
+
+    def test_non_graph_rejected(self) -> None:
+        app = self._app()
+        with pytest.raises(TypeError, match="invoke"):
+            app.register_service_bus(object(), "x", connection="SB", queue_name="q")
+
+    def test_public_error_exported(self) -> None:
+        import azure_functions_langgraph as pkg
+
+        assert pkg.ThreadContentionError is ThreadContentionError
+        assert pkg.default_message_mapper is default_message_mapper


### PR DESCRIPTION
## Summary
- Adds `LangGraphApp.register_service_bus(...)` to drive a compiled LangGraph graph from an Azure Service Bus **queue** or **topic-subscription** message — one `invoke`/`ainvoke` per delivery, independent of the HTTP endpoints (a graph may be registered on both surfaces).
- New `triggers/service_bus.py`: `default_message_mapper` (UTF-8 + JSON body → graph input, object passthrough else wrap as a human message), `ServiceBusMessageLike` protocol, sync + async `process_service_bus_message*`, and `ThreadContentionError`.
- Threadless by default; opt into checkpointed runs with `thread_id_factory`, guarded by the package's existing `ThreadLock` (contention raises so the broker retries). Graph exceptions are **never swallowed**; no output binding (use `result_handler`). No payload leakage in telemetry — runs carry a `trigger_type="service_bus"` correlation field.

## Design boundaries (per #409)
- No exactly-once / dedup (Service Bus is at-least-once; graphs must be idempotent).
- A message is not implicitly a thread.
- Graph exceptions propagate so the broker abandons/dead-letters.
- No Service Bus output publishing in this issue.

## Docs & examples
- `examples/service_bus_agent/` (graph, function_app, README with **HTTP vs Service Bus** decision table, host.json, local.settings example, requirements).
- README Service Bus section + decision table; `examples/README.md` row and picker line.

## Tests
- `tests/test_service_bus.py` — mapper variants, sync/async run paths, lock/contention/failure/result-handler branches, all `register_service_bus` validation branches, public-export check.
- Registered the example in `tests/test_examples_smoke.py`; extended `tests/test_public_api.py` for the new `__all__` symbols.
- Full suite green; coverage **96.18%** (≥95% gate). `triggers/service_bus.py` at 100%. Lint + mypy clean.

## Deferred
- Real-Azure e2e certification (cannot run in this environment) — the deterministic suite covers library behavior.