### PR TITLE
feat(streaming): add opt-in true HTTP streaming via StreamingLangGraphApp

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -146,7 +146,7 @@ Functions and talk to them with `langgraph-sdk`." If your application relies
 on any of the following, **prefer LangGraph Platform** (or another long-running
 host) over this package:
 
-- True token-level streaming (vs. buffered SSE)
+- True token-level streaming on the **Platform-compatible** endpoints (vs. buffered SSE) — note the native `StreamingLangGraphApp` does offer true incremental SSE, but only on its native `/api/graphs/{name}/stream` route, not the Platform-compatible surface
 - `interrupt_before` / `interrupt_after` flows
 - Webhook callbacks on run completion
 - Resumption from a specific `checkpoint_id` or via `command`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This package provides a focused adapter for serving LangGraph graphs on Azure Fu
 
 - **Zero-boilerplate deployment** — register a compiled graph, get HTTP endpoints automatically
 - **Invoke endpoint** — `POST /api/graphs/{name}/invoke` for synchronous execution
-- **Stream endpoint** — `POST /api/graphs/{name}/stream` for buffered SSE responses
+- **Stream endpoint** — `POST /api/graphs/{name}/stream` for buffered SSE responses (opt into true incremental streaming with `StreamingLangGraphApp`)
 - **Health endpoints** — anonymous `GET /api/health` liveness probe (`{"status": "ok"}`, no graph inventory) plus protected `GET /api/health/details` listing registered graphs with checkpointer status
 - **Checkpointer pass-through** — thread-based conversation state works via LangGraph's native config
 - **State endpoint** — `GET /api/graphs/{name}/threads/{thread_id}/state` for thread state inspection (when supported)
@@ -64,7 +64,7 @@ This package provides a focused adapter for serving LangGraph graphs on Azure Fu
 | Runs | Built-in | Threaded + threadless runs (v0.4+) |
 | State read/update | Built-in | get_state + update_state (v0.4+) |
 | State history | Built-in | Checkpoint history with filtering (v0.4+) |
-| Streaming | True SSE | Buffered SSE |
+| Streaming | True SSE | Buffered SSE (opt-in true SSE via `StreamingLangGraphApp`) |
 | Persistent storage | Built-in | Azure Blob + Table Storage (v0.4+) |
 | Infrastructure | Managed | Azure Functions (serverless) |
 | Cost model | Per-seat/usage | Azure Functions pricing |
@@ -279,20 +279,41 @@ app_local = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
 
 ### Streaming behavior
 
-> **Important:** All `/stream` endpoints (both the native `POST /api/graphs/{name}/stream`
-> and the Platform-compatible `POST /threads/{id}/runs/stream` and `POST /runs/stream`)
+> **Default (`LangGraphApp`): buffered SSE.** All `/stream` endpoints on the classic
+> `LangGraphApp` (the native `POST /api/graphs/{name}/stream` and the
+> Platform-compatible `POST /threads/{id}/runs/stream` and `POST /runs/stream`)
 > return **buffered SSE**. Chunks emitted by the graph are collected during execution
 > and flushed as SSE events **after the run completes** — this is **not** true
 > token-level streaming, and clients will not receive partial tokens incrementally.
+> Buffered SSE is the classic adapter's deliberate implementation choice, because the
+> classic `HttpRequest`/`HttpResponse` model it is built on cannot flush a response
+> incrementally.
 >
-> Buffered SSE is **this adapter's current implementation choice**, not an Azure
-> Functions platform limitation. Azure Functions Python v2 *does* support true HTTP
-> streaming (runtime 4.34.1+) via the `azurefunctions-extensions-http-fastapi`
-> extension, but enabling it switches the **entire function app** to the FastAPI/ASGI
-> streaming model, which cannot be mixed with the classic `HttpRequest`/`HttpResponse`
-> routes this package is built on. Adopting true streaming is therefore an app-wide
-> architectural change (tracked separately). If you need real-time token streaming
-> today, run the graph behind a long-running host (e.g. App Service or AKS) instead.
+> **Opt-in true streaming: `StreamingLangGraphApp` (experimental).** For genuine
+> incremental delivery — each `event: data` frame flushed **as the graph produces
+> it** — use the separate `StreamingLangGraphApp`. It serves the graph over the
+> FastAPI/ASGI transport provided by the `azurefunctions-extensions-http-fastapi`
+> extension (Azure Functions runtime **4.34.1+**), gated behind the `streaming` extra:
+>
+> ```bash
+> pip install "azure-functions-langgraph[streaming]"
+> ```
+>
+> ```python
+> from azure_functions_langgraph import StreamingLangGraphApp
+>
+> app = StreamingLangGraphApp()
+> app.register(graph=graph, name="my_agent")
+> func_app = app.function_app
+> ```
+>
+> Enabling true streaming converts the **entire** function app to the ASGI model, so
+> it cannot be mixed with classic `LangGraphApp` routes in the same app — deploy a
+> separate app if you also need the classic buffered surface, and note the classic
+> `max_stream_response_bytes` byte guard is replaced by `max_stream_events` (a frame
+> count cap) because a true stream is never buffered. `LangGraphApp` is unchanged and
+> remains the default. See [`examples/true_streaming_agent/`](examples/true_streaming_agent/)
+> for a runnable `curl -N` walkthrough that proves incremental arrival.
 
 ### Run observability
 
@@ -469,7 +490,7 @@ to `""` to remove the prefix entirely.
 ### What you get
 
 - `POST /api/graphs/echo_agent/invoke` — invoke the agent
-- `POST /api/graphs/echo_agent/stream` — stream agent responses (buffered SSE, not true token streaming)
+- `POST /api/graphs/echo_agent/stream` — stream agent responses (buffered SSE; opt into true incremental streaming with `StreamingLangGraphApp`)
 - `GET /api/graphs/echo_agent/threads/{thread_id}/state` — inspect thread state
 - `GET /api/health` — liveness probe (`{"status": "ok"}`)
 - `GET /api/health/details` — registered-graph inventory (protected by default)

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@
 | Curl helpers | [`local_curl`](local_curl/) | Shell scripts for hitting every Quick Start endpoint locally. |
 | Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
 | Service Bus trigger | [`service_bus_agent`](service_bus_agent/) | Drive a graph from an Azure Service Bus **queue** message via `register_service_bus` — one `invoke` per message, exceptions not swallowed. |
+| True HTTP streaming | [`true_streaming_agent`](true_streaming_agent/) | Opt into **true** incremental SSE with `StreamingLangGraphApp` — each `event: data` frame flushed as the graph produces it, over the FastAPI/ASGI transport (`streaming` extra, runtime 4.34.1+). |
 
 ## Conventions
 
@@ -60,3 +61,4 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 - **Shipping run telemetry to Application Insights (KQL dashboards)?** → `observability_app_insights`
 - **Recovering orphaned run locks automatically?** → `maintenance_timer`
 - **Driving a graph from Service Bus messages (background jobs, decoupled pipelines)?** → `service_bus_agent`
+- **Need true incremental token streaming (not buffered SSE)?** → `true_streaming_agent`

--- a/examples/true_streaming_agent/README.md
+++ b/examples/true_streaming_agent/README.md
@@ -1,0 +1,89 @@
+# True streaming agent
+
+A LangGraph agent served with **true** incremental HTTP streaming via
+[`StreamingLangGraphApp`](../../src/azure_functions_langgraph/streaming.py).
+
+Every other example in this repo uses `LangGraphApp`, whose `/stream` endpoint
+returns **buffered** SSE — chunks are collected during the run and flushed only
+after it completes. This example instead uses `StreamingLangGraphApp`, which
+flushes each `event: data` frame **as the graph produces it**, so a client sees
+partial output arrive incrementally.
+
+## How it differs from the buffered examples
+
+| | `LangGraphApp` (buffered) | `StreamingLangGraphApp` (true streaming) |
+|---|---|---|
+| Transport | Classic `HttpRequest`/`HttpResponse` | FastAPI/ASGI (`azurefunctions-extensions-http-fastapi`) |
+| `/stream` delivery | Collected, flushed after the run | Each frame flushed as produced |
+| Runtime floor | Any supported | **4.34.1+** |
+| Extra required | none | `azure-functions-langgraph[streaming]` |
+| Mixing with classic routes | n/a | **No** — the whole app is ASGI |
+| State endpoint | included | intentionally excluded (use `LangGraphApp`) |
+
+> **App-wide switch.** Enabling true streaming converts the **entire** function
+> app to the ASGI streaming model. You cannot mix classic and streaming routes
+> in one app — deploy a separate app if you also need the classic buffered
+> surface.
+
+## Prerequisites
+
+- Azure Functions runtime **4.34.1+**
+- `pip install "azure-functions-langgraph[streaming]"`
+- App setting **`PYTHON_ENABLE_INIT_INDEXING=1`** (see `local.settings.json.example`)
+
+## Run locally
+
+```bash
+pip install -r requirements.txt
+cp local.settings.json.example local.settings.json
+func start
+```
+
+## Prove incremental delivery with `curl -N`
+
+`-N` disables curl's output buffering so you can watch frames land one at a time.
+The graph is a three-step pipeline. With `stream_mode: "updates"` you receive one
+`event: data` frame per step (the node's delta), then a terminal `event: end`:
+
+```bash
+curl -N -X POST "http://localhost:7071/api/graphs/true_streaming_agent/stream?code=<FUNCTION_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"messages": [{"role": "human", "content": "hello world"}], "tokens": []}, "stream_mode": "updates"}'
+```
+
+```text
+event: data
+data: {"step_1": {"tokens": ["Echo:"]}}
+
+event: data
+data: {"step_2": {"tokens": ["Echo:", "hello"]}}
+
+event: data
+data: {"step_3": {"tokens": ["Echo:", "hello", "world"], "messages": [...]}}
+
+event: end
+data: {}
+```
+
+Each block appears as its step finishes — not all at once at the end. Swap
+`stream_mode` in the request body (`"values"`, `"updates"`, `"messages"`, ...) to
+change the event shape; the framing (`event: data` / `event: end`, plus
+`event: error` if the graph raises mid-stream) is unchanged.
+
+## Endpoints
+
+- `POST /api/graphs/true_streaming_agent/invoke` — synchronous invocation (JSON)
+- `POST /api/graphs/true_streaming_agent/stream` — **true** incremental SSE
+- `GET /api/health` — anonymous liveness probe (`{"status": "ok"}`)
+- `GET /api/health/details` — registered-graph inventory (protected)
+
+> The Platform-compatible and thread-state surfaces are **not** part of the
+> streaming app. If you need those, keep serving them from a classic
+> `LangGraphApp` deployment.
+
+## Safety cap
+
+A true stream is never buffered, so the buffered-response byte guard
+(`LangGraphApp.max_stream_response_bytes`) does not apply. Instead
+`StreamingLangGraphApp(max_stream_events=...)` bounds the number of frames a
+single run may emit; exceeding it emits an `event: error` frame and stops.

--- a/examples/true_streaming_agent/function_app.py
+++ b/examples/true_streaming_agent/function_app.py
@@ -1,0 +1,38 @@
+"""True-streaming agent — Azure Functions entry point.
+
+Serves a LangGraph graph with **true** incremental HTTP streaming using
+``StreamingLangGraphApp``. Each event the graph emits is flushed to the client
+as it is produced (``event: data`` frames), followed by a terminal ``event: end``.
+
+> **App-wide ASGI mode.** Enabling true streaming switches the **entire**
+> function app to the FastAPI/ASGI streaming model
+> (``azurefunctions-extensions-http-fastapi``). It cannot be mixed with the
+> classic ``HttpRequest``/``HttpResponse`` routes used by ``LangGraphApp`` — a
+> single app is either classic *or* streaming, not both. If you need the classic
+> buffered surface too, deploy it as a separate function app.
+
+Prerequisites:
+    - Azure Functions runtime **4.34.1+**
+    - The ``streaming`` extra: ``pip install "azure-functions-langgraph[streaming]"``
+    - App setting ``PYTHON_ENABLE_INIT_INDEXING=1``
+
+Run from this directory:
+    func start
+"""
+
+from __future__ import annotations
+
+import azure.functions as func
+from graph import compiled_graph
+
+from azure_functions_langgraph.streaming import StreamingLangGraphApp
+
+langgraph_app = StreamingLangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+
+langgraph_app.register(
+    graph=compiled_graph,
+    name="true_streaming_agent",
+)
+
+
+app = langgraph_app.function_app

--- a/examples/true_streaming_agent/graph.py
+++ b/examples/true_streaming_agent/graph.py
@@ -1,0 +1,93 @@
+"""True-streaming agent example — LangGraph graph served with incremental SSE.
+
+Unlike the other examples (which use ``LangGraphApp`` and buffered SSE), this
+example uses :class:`azure_functions_langgraph.streaming.StreamingLangGraphApp`,
+which serves ``POST /api/graphs/{name}/stream`` as **true** HTTP streaming: each
+event the graph emits is flushed to the client as it is produced, instead of
+being buffered until the run completes.
+
+To make incremental delivery visible without a real LLM, the graph is a small
+multi-step pipeline: each node appends one token, so ``graph.stream(...)`` yields
+one state update per step. Over the wire you therefore see one ``event: data``
+frame arrive per step (try ``curl -N`` — see the README).
+
+Requirements::
+
+    pip install "azure-functions-langgraph[streaming]" langgraph langchain-core
+
+Usage::
+
+    # In your function_app.py
+    from graph import compiled_graph
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import TypedDict
+
+# ------------------------------------------------------------------
+# 1. Define state
+# ------------------------------------------------------------------
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+    tokens: list[str]
+
+
+# ------------------------------------------------------------------
+# 2. Define node functions — one appended token per step
+# ------------------------------------------------------------------
+
+
+def _reply_words(state: AgentState) -> list[str]:
+    text = state["messages"][-1]["content"] if state["messages"] else ""
+    return ["Echo:", *text.split()] if text else ["Echo:"]
+
+
+def step_1(state: AgentState) -> dict[str, Any]:
+    words = _reply_words(state)
+    return {"tokens": words[:1]}
+
+
+def step_2(state: AgentState) -> dict[str, Any]:
+    words = _reply_words(state)
+    return {"tokens": words[:2]}
+
+
+def step_3(state: AgentState) -> dict[str, Any]:
+    words = _reply_words(state)
+    reply = " ".join(words)
+    return {
+        "tokens": words,
+        "messages": state["messages"] + [{"role": "assistant", "content": reply}],
+    }
+
+
+# ------------------------------------------------------------------
+# 3. Build the graph (using LangGraph API)
+# ------------------------------------------------------------------
+
+# NOTE: This block is guarded so the module can be imported without langgraph
+# installed (e.g. for testing the example structure).
+try:
+    from langgraph.graph import END, START, StateGraph
+
+    builder = StateGraph(AgentState)
+    builder.add_node("step_1", step_1)
+    builder.add_node("step_2", step_2)
+    builder.add_node("step_3", step_3)
+    builder.add_edge(START, "step_1")
+    builder.add_edge("step_1", "step_2")
+    builder.add_edge("step_2", "step_3")
+    builder.add_edge("step_3", END)
+
+    compiled_graph = builder.compile()
+
+except ImportError:
+    raise ImportError(
+        "langgraph is required for this example. "
+        "Install it with: pip install langgraph langchain-core"
+    )

--- a/examples/true_streaming_agent/host.json
+++ b/examples/true_streaming_agent/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/true_streaming_agent/local.settings.json.example
+++ b/examples/true_streaming_agent/local.settings.json.example
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "PYTHON_ENABLE_INIT_INDEXING": "1"
+  }
+}

--- a/examples/true_streaming_agent/requirements.txt
+++ b/examples/true_streaming_agent/requirements.txt
@@ -1,0 +1,9 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+# True HTTP streaming requires the 'streaming' extra
+# (azurefunctions-extensions-http-fastapi) and Azure Functions runtime 4.34.1+.
+azure-functions
+azure-functions-langgraph[streaming]>=0.8,<0.9
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ cosmos = [
 otel = [
     "opentelemetry-api>=1.20,<2",
 ]
+streaming = [
+    "azurefunctions-extensions-http-fastapi>=1.0,<2",
+]
 dev = [
     "bandit==1.9.4",
     "build",
@@ -89,6 +92,9 @@ dev = [
     # SDK + in-memory exporter are test-only; the runtime extra needs only the API.
     "opentelemetry-api>=1.20,<2",
     "opentelemetry-sdk>=1.20,<2",
+    # True HTTP streaming transport (StreamingLangGraphApp) — the streaming extra,
+    # installed here so CI covers the ASGI/FastAPI extension import path.
+    "azurefunctions-extensions-http-fastapi>=1.0,<2",
 ]
 docs = [
     "mkdocs<2.0",

--- a/src/azure_functions_langgraph/__init__.py
+++ b/src/azure_functions_langgraph/__init__.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
         StatefulGraph,
         StreamableGraph,
     )
+    from azure_functions_langgraph.streaming import StreamingLangGraphApp
     from azure_functions_langgraph.triggers.service_bus import (
         ServiceBusMessageLike,
         ThreadContentionError,
@@ -92,6 +93,11 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
         "azure_functions_langgraph.triggers.service_bus",
         "ThreadContentionError",
     ),
+    # Streaming transport (issue #406)
+    "StreamingLangGraphApp": (
+        "azure_functions_langgraph.streaming",
+        "StreamingLangGraphApp",
+    ),
 }
 
 # Symbols whose import failure means the optional runtime deps are missing;
@@ -102,6 +108,7 @@ _REQUIRES_RUNTIME_DEPS = frozenset({"LangGraphApp"})
 # install hint naming the extra instead of the raw ImportError.
 _REQUIRES_EXTRA: dict[str, str] = {
     "OTelRunObserver": "otel",
+    "StreamingLangGraphApp": "streaming",
 }
 
 
@@ -164,4 +171,6 @@ __all__ = [
     "default_message_mapper",
     "ServiceBusMessageLike",
     "ThreadContentionError",
+    # Streaming
+    "StreamingLangGraphApp",
 ]

--- a/src/azure_functions_langgraph/streaming.py
+++ b/src/azure_functions_langgraph/streaming.py
@@ -1,0 +1,800 @@
+"""StreamingLangGraphApp — opt-in **true** HTTP/SSE streaming for LangGraph graphs.
+
+Unlike :class:`~azure_functions_langgraph.app.LangGraphApp`, whose ``/stream``
+endpoint returns **buffered** SSE (all chunks collected, then flushed after the
+run completes), this app serves ``/stream`` as a real, incrementally-flushed
+``text/event-stream`` response: each event LangGraph emits is written to the
+wire as soon as it is produced.
+
+This is a deliberately **separate** app type. Azure Functions Python v2 exposes
+true HTTP streaming only through the ``azurefunctions-extensions-http-fastapi``
+extension (runtime 4.34.1+), which switches the **entire** function app to the
+FastAPI/ASGI request/response model. That model cannot be mixed with the classic
+``azure.functions.HttpRequest``/``HttpResponse`` routes ``LangGraphApp`` is built
+on, so the classic app keeps its buffered contract untouched and callers opt in
+to true streaming by constructing :class:`StreamingLangGraphApp` instead (issue
+#406).
+
+Runtime prerequisites (a real deploy must satisfy all three):
+
+- Azure Functions runtime **4.34.1+**.
+- The ``streaming`` extra installed (``pip install
+  azure-functions-langgraph[streaming]``) so the FastAPI extension is present.
+- ``PYTHON_ENABLE_INIT_INDEXING=1`` in the Function App settings.
+
+Because enabling HTTP streaming makes the whole app FastAPI-based, **every**
+route here (health, invoke, stream) returns an extension response type; there is
+no classic-route fallback within a ``StreamingLangGraphApp``.
+
+Scope note: thread-state retrieval
+(``GET /graphs/{name}/threads/{thread_id}/state``) is intentionally **not**
+exposed on the streaming surface. Use the classic :class:`LangGraphApp` for
+state inspection; the streaming app is focused on invoke + true-streaming
+delivery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+from typing import Any, AsyncIterator, Optional
+import warnings
+
+import azure.functions as func
+
+from azure_functions_langgraph._handlers import (
+    _method_accepts_version,
+    _serialize_graph_output,
+)
+from azure_functions_langgraph._validation import (
+    validate_body_size,
+    validate_graph_name,
+    validate_input_structure,
+    validate_thread_id,
+)
+from azure_functions_langgraph.contracts import (
+    HealthResponse,
+    HealthStatus,
+    InvokeRequest,
+    InvokeResponse,
+    StreamRequest,
+    _is_model_type,
+)
+from azure_functions_langgraph.locks import InProcessThreadLock, ThreadLock
+from azure_functions_langgraph.observability import (
+    NoOpRunObserver,
+    RunContext,
+    RunObserver,
+    RunRejectedReason,
+    finish_context,
+    new_run_context,
+    safe_observer_call,
+)
+from azure_functions_langgraph.protocols import (
+    AsyncInvocableGraph,
+    AsyncStreamableGraph,
+    InvocableGraph,
+    StreamableGraph,
+)
+
+logger = logging.getLogger(__name__)
+
+# Route path templates — kept identical to the native LangGraphApp surface so a
+# streaming deployment answers the same URLs (minus the state endpoint).
+_ROUTE_HEALTH = "health"
+_ROUTE_HEALTH_DETAILS = "health/details"
+_ROUTE_INVOKE = "graphs/{name}/invoke"
+_ROUTE_STREAM = "graphs/{name}/stream"
+
+# Friendly install hint surfaced when the FastAPI extension is missing.
+_EXTRA_HINT = (
+    "StreamingLangGraphApp requires the optional 'streaming' extra "
+    "(the azurefunctions-extensions-http-fastapi extension). Install it with: "
+    "pip install azure-functions-langgraph[streaming]"
+)
+
+
+def _import_fastapi_extension() -> Any:
+    """Import the FastAPI extension response/request types, or raise a hint.
+
+    Kept lazy (not a module-level import) so ``import
+    azure_functions_langgraph.streaming`` stays cheap and the class can be
+    referenced for typing/metadata even when the ``streaming`` extra is not
+    installed. The friendly :class:`ImportError` names the extra to install.
+    """
+    try:
+        from azurefunctions.extensions.http import fastapi as ext
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise ImportError(_EXTRA_HINT) from exc
+    return ext
+
+
+# ------------------------------------------------------------------
+# Registration record
+# ------------------------------------------------------------------
+
+
+@dataclass
+class _StreamRegistration:
+    """Internal registration record for a compiled graph on the streaming app."""
+
+    graph: Any
+    name: str
+    description: Optional[str] = None
+    stream_enabled: bool = True
+    async_mode: bool = False
+    auth_level: Optional[func.AuthLevel] = None
+    request_model: Optional[type[Any]] = None
+    response_model: Optional[type[Any]] = None
+
+
+def _validate_optional_model(model: Optional[type[Any]], label: str) -> None:
+    """Reject a non-``BaseModel`` *model* early (mirrors ``app._validate_optional_model``)."""
+    if model is not None and not _is_model_type(model):
+        raise TypeError(f"{label} must be a Pydantic BaseModel subclass, got {model!r}")
+
+
+# ------------------------------------------------------------------
+# Request parsing helpers (Starlette Request → validated contract model)
+# ------------------------------------------------------------------
+
+
+async def _read_json_body(req: Any, *, max_request_body_bytes: int) -> Any:
+    """Read and JSON-decode a Starlette request body, enforcing the size cap.
+
+    Returns the decoded JSON object on success, or a ``_JsonError`` sentinel
+    carrying the ``(status_code, detail)`` to translate into a JSON response.
+    """
+    raw_body: bytes = await req.body()
+    size_err = validate_body_size(raw_body, max_request_body_bytes)
+    if size_err:
+        return _JsonError(400, size_err)
+    try:
+        return json.loads(raw_body) if raw_body else {}
+    except ValueError:
+        return _JsonError(400, "Invalid JSON body")
+
+
+@dataclass(frozen=True)
+class _JsonError:
+    """Internal marker for a pre-execution failure to render as a JSON error."""
+
+    status_code: int
+    detail: str
+
+
+def _validate_request(
+    body: Any,
+    model: type[Any],
+    *,
+    max_input_depth: int,
+    max_input_nodes: int,
+) -> Any:
+    """Validate a decoded body against *model* and its input/config structure.
+
+    Returns the validated model instance, or a ``_JsonError`` on failure.
+    """
+    try:
+        request = model.model_validate(body)
+    except Exception as exc:  # noqa: BLE001 - surfaced as a 422 to the caller
+        return _JsonError(422, f"Validation error: {exc}")
+    structure_err = validate_input_structure(
+        request.input, max_depth=max_input_depth, max_nodes=max_input_nodes
+    )
+    if structure_err:
+        return _JsonError(400, structure_err)
+    if request.config:
+        config_err = validate_input_structure(
+            request.config, max_depth=max_input_depth, max_nodes=max_input_nodes
+        )
+        if config_err:
+            return _JsonError(400, config_err)
+    return request
+
+
+def _extract_thread_id(config: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Extract ``thread_id`` from ``config.configurable`` (mirrors ``_handlers``)."""
+    configurable = config.get("configurable")
+    if configurable is None:
+        return None, None
+    if not isinstance(configurable, dict):
+        return None, "config.configurable must be an object"
+    thread_id = configurable.get("thread_id")
+    if thread_id is None:
+        return None, None
+    if not isinstance(thread_id, str):
+        return None, "config.configurable.thread_id must be a string"
+    tid_err = validate_thread_id(thread_id)
+    if tid_err:
+        return None, tid_err
+    return thread_id, None
+
+
+def _resolve_version_kwarg(
+    method: Any, version: str | None, graph_name: str
+) -> dict[str, str] | _JsonError:
+    """Resolve a caller ``version`` request into forwardable kwargs, or a 422."""
+    if version is None:
+        return {}
+    if not _method_accepts_version(method):
+        return _JsonError(
+            422,
+            f"Graph {graph_name!r} does not accept a 'version' argument (requires langgraph>=1.1)",
+        )
+    return {"version": version}
+
+
+# ------------------------------------------------------------------
+# The true-streaming SSE generator (extension-independent, fully testable)
+# ------------------------------------------------------------------
+
+
+async def _aiter_graph_events(
+    graph: Any,
+    input_: dict[str, Any],
+    config: dict[str, Any],
+    stream_mode: str,
+    version_kwargs: dict[str, str],
+) -> AsyncIterator[Any]:
+    """Yield graph stream events incrementally for sync or async graphs.
+
+    An :class:`AsyncStreamableGraph` is consumed with ``async for``. A
+    synchronous :class:`StreamableGraph` is pulled one item at a time via
+    :func:`asyncio.to_thread`, so a blocking sync generator never stalls the
+    event loop between chunks (preserving incremental delivery).
+    """
+    if isinstance(graph, AsyncStreamableGraph):
+        async for event in graph.astream(
+            input_, config=config, stream_mode=stream_mode, **version_kwargs
+        ):
+            yield event
+        return
+
+    iterator = graph.stream(input_, config=config, stream_mode=stream_mode, **version_kwargs)
+    sentinel = object()
+    while True:
+        item = await asyncio.to_thread(next, iterator, sentinel)
+        if item is sentinel:
+            break
+        yield item
+
+
+def _format_data_event(event: Any) -> str:
+    """Serialize one graph event as an SSE ``data`` frame (native wire format)."""
+    serialized = json.dumps(
+        event if isinstance(event, dict) else {"data": str(event)},
+        default=str,
+        allow_nan=False,
+    )
+    return f"event: data\ndata: {serialized}\n\n"
+
+
+async def _sse_event_stream(
+    *,
+    graph: Any,
+    graph_name: str,
+    input_: dict[str, Any],
+    config: dict[str, Any],
+    stream_mode: str,
+    version_kwargs: dict[str, str],
+    thread_id: str | None,
+    lock_token: str | None,
+    thread_lock: ThreadLock,
+    observer: RunObserver,
+    ctx: RunContext,
+    max_stream_events: int,
+) -> AsyncIterator[str]:
+    """Produce a true-streaming SSE body, one frame at a time.
+
+    Contract (mirrors the native buffered handler's event vocabulary, but each
+    frame is flushed as produced):
+
+    - ``event: data`` per graph event, encoded exactly like the buffered path.
+    - ``event: error`` if the graph raises **after** streaming has begun, or if
+      the ``max_stream_events`` safety cap is hit — followed by ``event: end``.
+    - ``event: end`` terminates every completed stream.
+
+    Safety-cap note (replaces ``LangGraphApp.max_stream_response_bytes``): a
+    true stream is never buffered, so a byte cap on a materialized body is
+    meaningless. Instead ``max_stream_events`` bounds the number of frames a
+    single run may emit; exceeding it emits an ``error`` frame and stops.
+
+    The thread lock (acquired by the caller before the response headers were
+    sent) is released in ``finally`` for the **entire** stream lifetime — on
+    normal completion, on graph error, and on client disconnect
+    (:class:`asyncio.CancelledError`).
+    """
+    stream_error: BaseException | None = None
+    count = 0
+    released = False
+    try:
+        async for event in _aiter_graph_events(graph, input_, config, stream_mode, version_kwargs):
+            yield _format_data_event(event)
+            count += 1
+            if count >= max_stream_events:
+                stream_error = RuntimeError(f"stream exceeded max events ({max_stream_events})")
+                payload = json.dumps({"error": f"stream exceeded max events ({max_stream_events})"})
+                yield f"event: error\ndata: {payload}\n\n"
+                break
+    except asyncio.CancelledError:
+        # Client disconnected mid-stream. Release the lock (finally) and report
+        # the run as failed, then propagate the cancellation.
+        logger.info("Graph %s stream cancelled (client disconnect)", graph_name)
+        if lock_token is not None and thread_id is not None:
+            await asyncio.to_thread(thread_lock.release, graph_name, thread_id, lock_token)
+            released = True
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), asyncio.CancelledError())
+        raise
+    except Exception as exc:  # noqa: BLE001 - surfaced as an SSE error frame
+        logger.exception("Graph %s stream failed", graph_name)
+        stream_error = exc
+        payload = json.dumps({"error": "stream processing failed"})
+        yield f"event: error\ndata: {payload}\n\n"
+    finally:
+        # Normal / error path (the cancellation path released above and re-raised).
+        if lock_token is not None and thread_id is not None and not released:
+            await asyncio.to_thread(thread_lock.release, graph_name, thread_id, lock_token)
+
+    yield "event: end\ndata: {}\n\n"
+
+    if stream_error is not None:
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), stream_error)
+    else:
+        safe_observer_call(observer, "on_run_completed", finish_context(ctx))
+
+# ------------------------------------------------------------------
+# The app
+# ------------------------------------------------------------------
+
+
+@dataclass
+class StreamingLangGraphApp:
+    """Deploy LangGraph graphs as Azure Functions with **true** HTTP streaming.
+
+    Usage::
+
+        from azure_functions_langgraph.streaming import StreamingLangGraphApp
+
+        app = StreamingLangGraphApp()
+        app.register(graph=compiled_graph, name="my_agent")
+        func_app = app.function_app
+
+    Auto-registers:
+
+    - ``POST /api/graphs/{name}/invoke`` — synchronous invocation (JSON body)
+    - ``POST /api/graphs/{name}/stream`` — **true** incremental SSE stream
+    - ``GET /api/health`` — anonymous liveness probe (``{"status": "ok"}``)
+    - ``GET /api/health/details`` — registered-graph inventory (protected)
+
+    Requires the ``streaming`` extra and Azure Functions runtime 4.34.1+ (see
+    the module docstring for the full prerequisite list). Accessing
+    :attr:`function_app` without the extra installed raises a friendly
+    :class:`ImportError`.
+    """
+
+    auth_level: func.AuthLevel = func.AuthLevel.FUNCTION
+    health_auth_level: func.AuthLevel = func.AuthLevel.ANONYMOUS
+    health_details_auth_level: Optional[func.AuthLevel] = None
+    max_request_body_bytes: int = 1024 * 1024
+    max_input_depth: int = 32
+    max_input_nodes: int = 10_000
+    # Replaces LangGraphApp.max_stream_response_bytes: a true stream is not
+    # buffered, so it is bounded by a per-run event count instead of a body size.
+    max_stream_events: int = 100_000
+    thread_lock: Optional[ThreadLock] = None
+    observer: Optional[RunObserver] = None
+    route_prefix: str = "/api"
+    _registrations: dict[str, _StreamRegistration] = field(default_factory=dict)
+    _function_app: Optional[func.FunctionApp] = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.auth_level == func.AuthLevel.ANONYMOUS:
+            warnings.warn(
+                "StreamingLangGraphApp is using ANONYMOUS auth. Endpoints are "
+                "publicly accessible without authentication.\n"
+                "  Recommended: StreamingLangGraphApp(auth_level=func.AuthLevel.FUNCTION)",
+                UserWarning,
+                stacklevel=2,
+            )
+        if not self.route_prefix.startswith("/"):
+            self.route_prefix = "/" + self.route_prefix
+        self.route_prefix = self.route_prefix.rstrip("/") or "/"
+        if self.thread_lock is None:
+            self.thread_lock = InProcessThreadLock()
+        if self.observer is None:
+            self.observer = NoOpRunObserver()
+        env_backend = os.environ.get("AZFUNC_LANGGRAPH_LOCK_BACKEND", "").strip().lower()
+        if env_backend and env_backend not in ("", "inprocess"):
+            if isinstance(self.thread_lock, InProcessThreadLock):
+                raise RuntimeError(
+                    f"AZFUNC_LANGGRAPH_LOCK_BACKEND={env_backend!r} requires a "
+                    "distributed thread_lock backend (for example "
+                    "AzureBlobLeaseThreadLock), but the app is still using the "
+                    "default InProcessThreadLock. Pass thread_lock=... explicitly "
+                    "to StreamingLangGraphApp() or unset the env var for local dev."
+                )
+
+    def register(
+        self,
+        graph: Any,
+        name: str,
+        description: Optional[str] = None,
+        stream: bool = True,
+        auth_level: Optional[func.AuthLevel] = None,
+        *,
+        request_model: Optional[type[Any]] = None,
+        response_model: Optional[type[Any]] = None,
+        async_mode: bool = False,
+    ) -> None:
+        """Register a compiled LangGraph graph (mirrors ``LangGraphApp.register``).
+
+        Args:
+            graph: Any object satisfying the graph protocol (invoke/stream).
+            name: Unique name for this graph (used in URL routes).
+            description: Optional human-readable description.
+            stream: Whether to enable the true-streaming endpoint for this graph.
+            auth_level: Override app-level auth for this graph's endpoints.
+            request_model: Optional Pydantic model class for request body (metadata only).
+            response_model: Optional Pydantic model class for response body (metadata only).
+            async_mode: Route invoke/stream through the async graph methods.
+
+        Raises:
+            TypeError: If *graph* lacks invoke/ainvoke, or ``async_mode=True``
+                but the graph has no ``ainvoke``, or a supplied model is not a
+                Pydantic ``BaseModel`` subclass.
+            ValueError: If *name* is already registered or invalid.
+        """
+        has_sync_invoke = isinstance(graph, InvocableGraph)
+        has_async_invoke = isinstance(graph, AsyncInvocableGraph)
+        if async_mode and not has_async_invoke:
+            raise TypeError(
+                f"async_mode=True requires an ainvoke() method. Got {type(graph).__name__}"
+            )
+        if not has_sync_invoke and not has_async_invoke:
+            raise TypeError(
+                f"Graph must have an invoke() or ainvoke() method. Got {type(graph).__name__}"
+            )
+        _validate_optional_model(request_model, "request_model")
+        _validate_optional_model(response_model, "response_model")
+        name_err = validate_graph_name(name)
+        if name_err:
+            raise ValueError(name_err)
+        if name in self._registrations:
+            raise ValueError(f"Graph {name!r} is already registered")
+        self._registrations[name] = _StreamRegistration(
+            graph=graph,
+            name=name,
+            description=description,
+            stream_enabled=stream,
+            async_mode=async_mode,
+            auth_level=auth_level,
+            request_model=request_model,
+            response_model=response_model,
+        )
+        self._function_app = None
+
+    @property
+    def function_app(self) -> func.FunctionApp:
+        """Return an ``azure.functions.FunctionApp`` with all streaming routes wired.
+
+        Raises:
+            ImportError: If the ``streaming`` extra (FastAPI extension) is not
+                installed — the message names the extra to install.
+        """
+        if self._function_app is None:
+            self._function_app = self._build_function_app()
+        return self._function_app
+
+    @property
+    def _resolved_health_details_auth_level(self) -> func.AuthLevel:
+        if self.health_details_auth_level is None:
+            return self.auth_level
+        return self.health_details_auth_level
+
+    def _effective_auth_level(self, reg: _StreamRegistration) -> func.AuthLevel:
+        if reg.auth_level is not None:
+            return reg.auth_level
+        return self.auth_level
+
+    @staticmethod
+    def _is_async(reg: _StreamRegistration) -> bool:
+        """Whether a graph is served through the async invoke/stream path."""
+        return reg.async_mode or not isinstance(reg.graph, InvocableGraph)
+
+    # ------------------------------------------------------------------
+    # Route building
+    # ------------------------------------------------------------------
+
+    def _build_function_app(self) -> func.FunctionApp:
+        ext = _import_fastapi_extension()
+        Request = ext.Request
+        JSONResponse = ext.JSONResponse
+        StreamingResponse = ext.StreamingResponse
+
+        app = func.FunctionApp(http_auth_level=self.auth_level)
+        observer = self.observer or NoOpRunObserver()
+        thread_lock = self.thread_lock
+        if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
+            raise RuntimeError("thread_lock is None; __post_init__ did not run")
+
+        # --- Health endpoints -----------------------------------------
+        @app.function_name(name="aflg_health")
+        @app.route(route=_ROUTE_HEALTH, methods=["GET"], auth_level=self.health_auth_level)
+        async def health(req: Any) -> Any:
+            return JSONResponse(content=json.loads(HealthStatus().model_dump_json()))
+
+        @app.function_name(name="aflg_health_details")
+        @app.route(
+            route=_ROUTE_HEALTH_DETAILS,
+            methods=["GET"],
+            auth_level=self._resolved_health_details_auth_level,
+        )
+        async def health_details(req: Any) -> Any:
+            from azure_functions_langgraph.contracts import GraphInfo
+
+            graphs = [
+                GraphInfo(
+                    name=reg.name,
+                    description=reg.description,
+                    has_checkpointer=getattr(reg.graph, "checkpointer", None) is not None,
+                )
+                for reg in self._registrations.values()
+            ]
+            body = HealthResponse(graphs=graphs)
+            return JSONResponse(content=json.loads(body.model_dump_json()))
+
+        # --- Per-graph endpoints --------------------------------------
+        for reg in self._registrations.values():
+            self._register_invoke(app, reg, Request, JSONResponse, observer, thread_lock)
+            if reg.stream_enabled:
+                self._register_stream(
+                    app, reg, Request, JSONResponse, StreamingResponse, observer, thread_lock
+                )
+
+        return app
+
+    def _register_invoke(
+        self,
+        app: func.FunctionApp,
+        reg: _StreamRegistration,
+        Request: Any,
+        JSONResponse: Any,
+        observer: RunObserver,
+        thread_lock: ThreadLock,
+    ) -> None:
+        captured = reg
+        is_async = self._is_async(reg)
+        effective_auth = self._effective_auth_level(reg)
+        route = _ROUTE_INVOKE.format(name=reg.name)
+        fn_name = f"aflg_{reg.name}_invoke"
+
+        async def invoke(req: Any) -> Any:
+            return await self._handle_invoke(
+                req, captured, is_async, JSONResponse, observer, thread_lock
+            )
+
+        app.function_name(name=fn_name)(
+            app.route(route=route, methods=["POST"], auth_level=effective_auth)(invoke)
+        )
+
+    def _register_stream(
+        self,
+        app: func.FunctionApp,
+        reg: _StreamRegistration,
+        Request: Any,
+        JSONResponse: Any,
+        StreamingResponse: Any,
+        observer: RunObserver,
+        thread_lock: ThreadLock,
+    ) -> None:
+        captured = reg
+        is_async = self._is_async(reg)
+        effective_auth = self._effective_auth_level(reg)
+        route = _ROUTE_STREAM.format(name=reg.name)
+        fn_name = f"aflg_{reg.name}_stream"
+
+        async def stream(req: Any) -> Any:
+            return await self._handle_stream(
+                req, captured, is_async, JSONResponse, StreamingResponse, observer, thread_lock
+            )
+
+        app.function_name(name=fn_name)(
+            app.route(route=route, methods=["POST"], auth_level=effective_auth)(stream)
+        )
+
+    # ------------------------------------------------------------------
+    # Handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_invoke(
+        self,
+        req: Any,
+        reg: _StreamRegistration,
+        is_async: bool,
+        JSONResponse: Any,
+        observer: RunObserver,
+        thread_lock: ThreadLock,
+    ) -> Any:
+        has_cp = getattr(reg.graph, "checkpointer", None) is not None
+        ctx = new_run_context(
+            reg.name,
+            "invoke",
+            transport="streaming",
+            has_checkpointer=has_cp,
+            lock_backend=type(thread_lock).__name__,
+        )
+
+        body = await _read_json_body(req, max_request_body_bytes=self.max_request_body_bytes)
+        if isinstance(body, _JsonError):
+            return self._reject(JSONResponse, observer, ctx, "invalid_request", body)
+        parsed = _validate_request(
+            body,
+            InvokeRequest,
+            max_input_depth=self.max_input_depth,
+            max_input_nodes=self.max_input_nodes,
+        )
+        if isinstance(parsed, _JsonError):
+            return self._reject(JSONResponse, observer, ctx, "invalid_request", parsed)
+        request = parsed
+
+        config = request.config or {}
+        thread_id, cfg_err = _extract_thread_id(config)
+        if cfg_err:
+            return self._reject(
+                JSONResponse, observer, ctx, "invalid_config", _JsonError(400, cfg_err)
+            )
+        ctx = dataclasses.replace(ctx, thread_id=thread_id)
+        method = reg.graph.ainvoke if is_async else reg.graph.invoke
+        version_kwargs = _resolve_version_kwarg(method, request.version, reg.name)
+        if isinstance(version_kwargs, _JsonError):
+            return self._reject(JSONResponse, observer, ctx, "unsupported_version", version_kwargs)
+
+        lock_token: str | None = None
+        if has_cp and thread_id:
+            lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
+            if not lock_token:
+                return self._reject(
+                    JSONResponse,
+                    observer,
+                    ctx,
+                    "lock_contention",
+                    _JsonError(409, f"Thread {thread_id!r} is currently in use by another request"),
+                )
+
+        safe_observer_call(observer, "on_run_started", ctx)
+        try:
+            if is_async:
+                result = await reg.graph.ainvoke(request.input, config=config, **version_kwargs)
+            else:
+                result = await asyncio.to_thread(
+                    lambda: reg.graph.invoke(request.input, config=config, **version_kwargs)
+                )
+        except Exception as exc:  # noqa: BLE001 - reported and returned as 500
+            logger.exception("Graph %s invoke failed", reg.name)
+            safe_observer_call(observer, "on_run_failed", finish_context(ctx), exc)
+            return self._json_error(JSONResponse, 500, "Graph execution failed")
+        finally:
+            if lock_token is not None and thread_id is not None:
+                await asyncio.to_thread(thread_lock.release, reg.name, thread_id, lock_token)
+
+        safe_observer_call(observer, "on_run_completed", finish_context(ctx))
+        output = _serialize_graph_output(result)
+        response = InvokeResponse(output=output)
+        return JSONResponse(content=json.loads(response.model_dump_json()), status_code=200)
+
+    async def _handle_stream(
+        self,
+        req: Any,
+        reg: _StreamRegistration,
+        is_async: bool,
+        JSONResponse: Any,
+        StreamingResponse: Any,
+        observer: RunObserver,
+        thread_lock: ThreadLock,
+    ) -> Any:
+        has_cp = getattr(reg.graph, "checkpointer", None) is not None
+        ctx = new_run_context(
+            reg.name,
+            "stream",
+            transport="streaming",
+            has_checkpointer=has_cp,
+            lock_backend=type(thread_lock).__name__,
+        )
+
+        streamable = isinstance(reg.graph, AsyncStreamableGraph if is_async else StreamableGraph)
+        if not streamable:
+            return self._reject(
+                JSONResponse,
+                observer,
+                ctx,
+                "streaming_unsupported",
+                _JsonError(501, f"Graph {reg.name!r} does not support streaming"),
+            )
+
+        body = await _read_json_body(req, max_request_body_bytes=self.max_request_body_bytes)
+        if isinstance(body, _JsonError):
+            return self._reject(JSONResponse, observer, ctx, "invalid_request", body)
+        parsed = _validate_request(
+            body,
+            StreamRequest,
+            max_input_depth=self.max_input_depth,
+            max_input_nodes=self.max_input_nodes,
+        )
+        if isinstance(parsed, _JsonError):
+            return self._reject(JSONResponse, observer, ctx, "invalid_request", parsed)
+        request = parsed
+
+        config = request.config or {}
+        thread_id, cfg_err = _extract_thread_id(config)
+        if cfg_err:
+            return self._reject(
+                JSONResponse, observer, ctx, "invalid_config", _JsonError(400, cfg_err)
+            )
+        ctx = dataclasses.replace(ctx, thread_id=thread_id, stream_mode=request.stream_mode)
+        method = reg.graph.astream if is_async else reg.graph.stream
+        version_kwargs = _resolve_version_kwarg(method, request.version, reg.name)
+        if isinstance(version_kwargs, _JsonError):
+            return self._reject(JSONResponse, observer, ctx, "unsupported_version", version_kwargs)
+
+        lock_token: str | None = None
+        if has_cp and thread_id:
+            lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
+            if not lock_token:
+                return self._reject(
+                    JSONResponse,
+                    observer,
+                    ctx,
+                    "lock_contention",
+                    _JsonError(409, f"Thread {thread_id!r} is currently in use by another request"),
+                )
+
+        # Past this point the response headers are committed and the run has
+        # started; any further failure is delivered as an in-band SSE error
+        # frame by the generator, not an HTTP status code.
+        safe_observer_call(observer, "on_run_started", ctx)
+        generator = _sse_event_stream(
+            graph=reg.graph,
+            graph_name=reg.name,
+            input_=request.input,
+            config=config,
+            stream_mode=request.stream_mode,
+            version_kwargs=version_kwargs,
+            thread_id=thread_id,
+            lock_token=lock_token,
+            thread_lock=thread_lock,
+            observer=observer,
+            ctx=ctx,
+            max_stream_events=self.max_stream_events,
+        )
+        return StreamingResponse(
+            generator,
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    # ------------------------------------------------------------------
+    # Response helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _json_error(JSONResponse: Any, status_code: int, detail: str) -> Any:
+        from azure_functions_langgraph.contracts import ErrorResponse
+
+        body = ErrorResponse(error="error", detail=detail)
+        return JSONResponse(content=json.loads(body.model_dump_json()), status_code=status_code)
+
+    def _reject(
+        self,
+        JSONResponse: Any,
+        observer: RunObserver,
+        ctx: RunContext,
+        reason: RunRejectedReason,
+        err: _JsonError,
+    ) -> Any:
+        """Emit ``on_run_rejected`` for a pre-execution failure and return a JSON error."""
+        safe_observer_call(observer, "on_run_rejected", finish_context(ctx), reason)
+        return self._json_error(JSONResponse, err.status_code, err.detail)

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -26,6 +26,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("observability_app_insights", "compiled_graph"),
     ("run_observer_otel", "compiled_graph"),
     ("service_bus_agent", "compiled_graph"),
+    ("true_streaming_agent", "compiled_graph"),
 )
 
 
@@ -83,6 +84,7 @@ EXAMPLE_DIRS = (
     "observability_app_insights",
     "run_observer_otel",
     "service_bus_agent",
+    "true_streaming_agent",
 )
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -57,6 +57,15 @@ def test_all_exports() -> None:
     assert "ServiceBusMessageLike" in azure_functions_langgraph.__all__
     assert "ThreadContentionError" in azure_functions_langgraph.__all__
 
+    # True streaming transport public surface
+    assert "StreamingLangGraphApp" in azure_functions_langgraph.__all__
+
+
+def test_streaming_app_importable() -> None:
+    from azure_functions_langgraph import StreamingLangGraphApp
+
+    assert StreamingLangGraphApp.__name__ == "StreamingLangGraphApp"
+
 
 def test_contracts_importable() -> None:
     from azure_functions_langgraph.contracts import (

--- a/tests/test_streaming_app.py
+++ b/tests/test_streaming_app.py
@@ -1,0 +1,957 @@
+"""Deterministic tests for the true-streaming transport (``StreamingLangGraphApp``).
+
+These tests exercise the streaming app without a live Azure Functions host. The
+FastAPI extension (``azurefunctions-extensions-http-fastapi``) is installed in
+the dev/CI environment, so ``function_app`` construction and the Starlette
+request/response plumbing are covered here; only the real-Azure proof of
+*incremental byte arrival* is deferred to the release-certification e2e.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, AsyncIterator, Iterator
+import warnings
+
+import azure.functions as func
+import pytest
+
+from azure_functions_langgraph.locks import InProcessThreadLock
+from azure_functions_langgraph.observability import (
+    NoOpRunObserver,
+    RunContext,
+    new_run_context,
+)
+from azure_functions_langgraph.streaming import (
+    StreamingLangGraphApp,
+    _aiter_graph_events,
+    _extract_thread_id,
+    _format_data_event,
+    _import_fastapi_extension,
+    _JsonError,
+    _read_json_body,
+    _resolve_version_kwarg,
+    _sse_event_stream,
+    _validate_optional_model,
+    _validate_request,
+)
+
+# The extension response/request types (installed via the ``streaming`` extra).
+_ext = _import_fastapi_extension()
+JSONResponse = _ext.JSONResponse
+StreamingResponse = _ext.StreamingResponse
+
+
+# ------------------------------------------------------------------
+# Fakes
+# ------------------------------------------------------------------
+
+
+class FakeRequest:
+    """Minimal duck-typed Starlette request — only ``body()`` is used."""
+
+    def __init__(self, payload: Any = None, *, raw: bytes | None = None) -> None:
+        if raw is not None:
+            self._raw = raw
+        elif payload is None:
+            self._raw = b""
+        else:
+            self._raw = json.dumps(payload).encode("utf-8")
+
+    async def body(self) -> bytes:
+        return self._raw
+
+
+class FakeSyncGraph:
+    """Sync invoke + stream graph."""
+
+    def __init__(
+        self, checkpointer: Any = None, chunks: list[dict[str, Any]] | None = None
+    ) -> None:
+        self.checkpointer = checkpointer
+        self._chunks = chunks or [
+            {"messages": [{"role": "assistant", "content": "a"}]},
+            {"messages": [{"role": "assistant", "content": "ab"}]},
+        ]
+
+    def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {"messages": [{"role": "assistant", "content": "final"}]}
+
+    def stream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+    ) -> Iterator[dict[str, Any]]:
+        yield from self._chunks
+
+
+class FakeAsyncGraph:
+    """Async ainvoke + astream graph."""
+
+    checkpointer = None
+
+    def __init__(self, chunks: list[dict[str, Any]] | None = None) -> None:
+        self._chunks = chunks or [{"n": 1}, {"n": 2}, {"n": 3}]
+
+    async def ainvoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {"ok": True}
+
+    async def astream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+    ) -> AsyncIterator[dict[str, Any]]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class FakeInvokeOnlyGraph:
+    """Graph without stream/astream."""
+
+    checkpointer = None
+
+    def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {"ok": True}
+
+
+class FailingStreamGraph:
+    """Streams one chunk then raises."""
+
+    checkpointer = None
+
+    def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {"ok": True}
+
+    def stream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+    ) -> Iterator[dict[str, Any]]:
+        yield {"messages": [{"role": "assistant", "content": "partial"}]}
+        raise RuntimeError("boom")
+
+
+class FailingInvokeGraph:
+    checkpointer = None
+
+    def invoke(self, input: dict[str, Any], config: dict[str, Any] | None = None) -> dict[str, Any]:
+        raise RuntimeError("invoke boom")
+
+
+class RecordingObserver:
+    """Records lifecycle callbacks for assertions."""
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+    def on_run_started(self, ctx: RunContext) -> None:
+        self.events.append("started")
+
+    def on_run_completed(self, ctx: RunContext) -> None:
+        self.events.append("completed")
+
+    def on_run_failed(self, ctx: RunContext, error: BaseException) -> None:
+        self.events.append("failed")
+
+    def on_run_rejected(self, ctx: RunContext, reason: str) -> None:
+        self.events.append(f"rejected:{reason}")
+
+
+class RecordingLock:
+    """ThreadLock stub that records release calls."""
+
+    def __init__(self, token: str | None = "tok") -> None:
+        self._token = token
+        self.acquired: list[tuple[str, str]] = []
+        self.released: list[tuple[str, str, str]] = []
+
+    def acquire(self, graph_name: str, thread_id: str, timeout: float = 0.0) -> str | None:
+        self.acquired.append((graph_name, thread_id))
+        return self._token
+
+    def release(self, graph_name: str, thread_id: str, token: str) -> None:
+        self.released.append((graph_name, thread_id, token))
+
+
+# ------------------------------------------------------------------
+# Helpers to drive handlers / generators
+# ------------------------------------------------------------------
+
+
+async def _collect(gen: AsyncIterator[str]) -> list[str]:
+    return [frame async for frame in gen]
+
+
+async def _read_stream_response(response: Any) -> list[str]:
+    frames: list[str] = []
+    async for chunk in response.body_iterator:
+        frames.append(chunk if isinstance(chunk, str) else chunk.decode("utf-8"))
+    return frames
+
+
+def _ctx() -> RunContext:
+    return new_run_context("g", "stream", transport="streaming", has_checkpointer=False)
+
+
+# ------------------------------------------------------------------
+# Pure helper unit tests
+# ------------------------------------------------------------------
+
+
+class TestPureHelpers:
+    def test_format_data_event_dict(self) -> None:
+        frame = _format_data_event({"a": 1})
+        assert frame == 'event: data\ndata: {"a": 1}\n\n'
+
+    def test_format_data_event_non_dict(self) -> None:
+        assert _format_data_event("hi") == 'event: data\ndata: {"data": "hi"}\n\n'
+
+    def test_extract_thread_id_none(self) -> None:
+        assert _extract_thread_id({}) == (None, None)
+
+    def test_extract_thread_id_configurable_not_dict(self) -> None:
+        tid, err = _extract_thread_id({"configurable": "nope"})
+        assert tid is None and err is not None
+
+    def test_extract_thread_id_not_string(self) -> None:
+        tid, err = _extract_thread_id({"configurable": {"thread_id": 5}})
+        assert tid is None and err is not None
+
+    def test_extract_thread_id_valid(self) -> None:
+        assert _extract_thread_id({"configurable": {"thread_id": "t1"}}) == ("t1", None)
+
+    def test_extract_thread_id_missing_thread(self) -> None:
+        assert _extract_thread_id({"configurable": {}}) == (None, None)
+
+    def test_validate_optional_model_rejects_non_model(self) -> None:
+        with pytest.raises(TypeError):
+            _validate_optional_model(dict, "request_model")
+
+    def test_validate_optional_model_allows_none(self) -> None:
+        _validate_optional_model(None, "request_model")
+
+    def test_resolve_version_none(self) -> None:
+        assert _resolve_version_kwarg(FakeSyncGraph().stream, None, "g") == {}
+
+    def test_resolve_version_unsupported(self) -> None:
+        result = _resolve_version_kwarg(FakeSyncGraph().stream, "v2", "g")
+        assert isinstance(result, _JsonError)
+        assert result.status_code == 422
+
+
+class TestReadJsonBody:
+    async def test_valid(self) -> None:
+        body = await _read_json_body(FakeRequest({"input": {}}), max_request_body_bytes=1024)
+        assert body == {"input": {}}
+
+    async def test_empty_body_is_empty_dict(self) -> None:
+        body = await _read_json_body(FakeRequest(raw=b""), max_request_body_bytes=1024)
+        assert body == {}
+
+    async def test_invalid_json(self) -> None:
+        body = await _read_json_body(FakeRequest(raw=b"{bad"), max_request_body_bytes=1024)
+        assert isinstance(body, _JsonError)
+        assert body.status_code == 400
+
+    async def test_oversize(self) -> None:
+        body = await _read_json_body(FakeRequest({"x": "y" * 100}), max_request_body_bytes=4)
+        assert isinstance(body, _JsonError)
+        assert body.status_code == 400
+
+
+class TestValidateRequest:
+    def test_valid(self) -> None:
+        from azure_functions_langgraph.contracts import InvokeRequest
+
+        parsed = _validate_request(
+            {"input": {"messages": []}}, InvokeRequest, max_input_depth=32, max_input_nodes=1000
+        )
+        assert not isinstance(parsed, _JsonError)
+
+    def test_model_validation_error(self) -> None:
+        from azure_functions_langgraph.contracts import InvokeRequest
+
+        parsed = _validate_request(
+            {"input": "not-a-dict"}, InvokeRequest, max_input_depth=32, max_input_nodes=1000
+        )
+        assert isinstance(parsed, _JsonError)
+        assert parsed.status_code == 422
+
+    def test_input_structure_too_deep(self) -> None:
+        from azure_functions_langgraph.contracts import InvokeRequest
+
+        parsed = _validate_request(
+            {"input": {"a": {"b": {"c": {}}}}},
+            InvokeRequest,
+            max_input_depth=1,
+            max_input_nodes=1000,
+        )
+        assert isinstance(parsed, _JsonError)
+        assert parsed.status_code == 400
+
+    def test_config_structure_too_deep(self) -> None:
+        from azure_functions_langgraph.contracts import InvokeRequest
+
+        parsed = _validate_request(
+            {"input": {}, "config": {"a": {"b": {"c": {}}}}},
+            InvokeRequest,
+            max_input_depth=1,
+            max_input_nodes=1000,
+        )
+        assert isinstance(parsed, _JsonError)
+        assert parsed.status_code == 400
+
+
+class TestAiterGraphEvents:
+    async def test_sync_graph(self) -> None:
+        events = [e async for e in _aiter_graph_events(FakeSyncGraph(), {}, {}, "values", {})]
+        assert len(events) == 2
+
+    async def test_async_graph(self) -> None:
+        events = [e async for e in _aiter_graph_events(FakeAsyncGraph(), {}, {}, "values", {})]
+        assert events == [{"n": 1}, {"n": 2}, {"n": 3}]
+
+
+# ------------------------------------------------------------------
+# _sse_event_stream generator
+# ------------------------------------------------------------------
+
+
+class TestSseEventStream:
+    async def test_normal_completion(self) -> None:
+        observer = RecordingObserver()
+        lock = RecordingLock()
+        frames = await _collect(
+            _sse_event_stream(
+                graph=FakeSyncGraph(),
+                graph_name="g",
+                input_={},
+                config={},
+                stream_mode="values",
+                version_kwargs={},
+                thread_id="t1",
+                lock_token="tok",
+                thread_lock=lock,
+                observer=observer,
+                ctx=_ctx(),
+                max_stream_events=100,
+            )
+        )
+        assert frames[0].startswith("event: data\n")
+        assert frames[-1] == "event: end\ndata: {}\n\n"
+        assert observer.events == ["completed"]
+        assert lock.released == [("g", "t1", "tok")]
+
+    async def test_no_lock_no_release(self) -> None:
+        lock = RecordingLock()
+        frames = await _collect(
+            _sse_event_stream(
+                graph=FakeSyncGraph(),
+                graph_name="g",
+                input_={},
+                config={},
+                stream_mode="values",
+                version_kwargs={},
+                thread_id=None,
+                lock_token=None,
+                thread_lock=lock,
+                observer=NoOpRunObserver(),
+                ctx=_ctx(),
+                max_stream_events=100,
+            )
+        )
+        assert frames[-1] == "event: end\ndata: {}\n\n"
+        assert lock.released == []
+
+    async def test_max_events_cap(self) -> None:
+        observer = RecordingObserver()
+        frames = await _collect(
+            _sse_event_stream(
+                graph=FakeSyncGraph(),
+                graph_name="g",
+                input_={},
+                config={},
+                stream_mode="values",
+                version_kwargs={},
+                thread_id=None,
+                lock_token=None,
+                thread_lock=RecordingLock(),
+                observer=observer,
+                ctx=_ctx(),
+                max_stream_events=1,
+            )
+        )
+        assert any(f.startswith("event: error\n") and "max events" in f for f in frames)
+        assert frames[-1] == "event: end\ndata: {}\n\n"
+        assert observer.events == ["failed"]
+
+    async def test_graph_error_after_first_frame(self) -> None:
+        observer = RecordingObserver()
+        lock = RecordingLock()
+        frames = await _collect(
+            _sse_event_stream(
+                graph=FailingStreamGraph(),
+                graph_name="g",
+                input_={},
+                config={},
+                stream_mode="values",
+                version_kwargs={},
+                thread_id="t1",
+                lock_token="tok",
+                thread_lock=lock,
+                observer=observer,
+                ctx=_ctx(),
+                max_stream_events=100,
+            )
+        )
+        assert frames[0].startswith("event: data\n")
+        assert any(f.startswith("event: error\n") for f in frames)
+        assert frames[-1] == "event: end\ndata: {}\n\n"
+        assert observer.events == ["failed"]
+        assert lock.released == [("g", "t1", "tok")]
+
+    async def test_client_disconnect_releases_lock_and_reraises(self) -> None:
+        observer = RecordingObserver()
+        lock = RecordingLock()
+
+        class SlowGraph:
+            checkpointer = None
+
+            def stream(
+                self,
+                input: dict[str, Any],
+                config: dict[str, Any] | None = None,
+                stream_mode: str = "values",
+            ) -> Iterator[dict[str, Any]]:
+                yield {"a": 1}
+                raise asyncio.CancelledError()
+
+        gen = _sse_event_stream(
+            graph=SlowGraph(),
+            graph_name="g",
+            input_={},
+            config={},
+            stream_mode="values",
+            version_kwargs={},
+            thread_id="t1",
+            lock_token="tok",
+            thread_lock=lock,
+            observer=observer,
+            ctx=_ctx(),
+            max_stream_events=100,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await _collect(gen)
+        # Released exactly once (in the cancellation arm, not double-released).
+        assert lock.released == [("g", "t1", "tok")]
+        assert observer.events == ["failed"]
+
+
+# ------------------------------------------------------------------
+# register() validation
+# ------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_duplicate_name(self) -> None:
+        app = StreamingLangGraphApp()
+        app.register(graph=FakeSyncGraph(), name="a")
+        with pytest.raises(ValueError):
+            app.register(graph=FakeSyncGraph(), name="a")
+
+    def test_invalid_name(self) -> None:
+        app = StreamingLangGraphApp()
+        with pytest.raises(ValueError):
+            app.register(graph=FakeSyncGraph(), name="bad name!")
+
+    def test_async_mode_without_ainvoke(self) -> None:
+        app = StreamingLangGraphApp()
+        with pytest.raises(TypeError):
+            app.register(graph=FakeSyncGraph(), name="a", async_mode=True)
+
+    def test_graph_without_invoke(self) -> None:
+        app = StreamingLangGraphApp()
+
+        class Empty:
+            pass
+
+        with pytest.raises(TypeError):
+            app.register(graph=Empty(), name="a")
+
+    def test_bad_request_model(self) -> None:
+        app = StreamingLangGraphApp()
+        with pytest.raises(TypeError):
+            app.register(graph=FakeSyncGraph(), name="a", request_model=dict)
+
+
+# ------------------------------------------------------------------
+# Construction
+# ------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_anonymous_warns(self) -> None:
+        with pytest.warns(UserWarning):
+            StreamingLangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+
+    def test_route_prefix_normalized(self) -> None:
+        app = StreamingLangGraphApp(route_prefix="v1/")
+        assert app.route_prefix == "/v1"
+
+    def test_empty_route_prefix(self) -> None:
+        app = StreamingLangGraphApp(route_prefix="")
+        assert app.route_prefix == "/"
+
+    def test_defaults_set(self) -> None:
+        app = StreamingLangGraphApp()
+        assert isinstance(app.thread_lock, InProcessThreadLock)
+        assert isinstance(app.observer, NoOpRunObserver)
+
+    def test_lock_backend_guard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AZFUNC_LANGGRAPH_LOCK_BACKEND", "distributed")
+        with pytest.raises(RuntimeError):
+            StreamingLangGraphApp()
+
+    def test_lock_backend_guard_allows_inprocess_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AZFUNC_LANGGRAPH_LOCK_BACKEND", "inprocess")
+        StreamingLangGraphApp()
+
+
+# ------------------------------------------------------------------
+# function_app construction (exercises the FastAPI extension import path)
+# ------------------------------------------------------------------
+
+
+class TestFunctionApp:
+    def test_builds_expected_functions(self) -> None:
+        app = StreamingLangGraphApp()
+        app.register(graph=FakeSyncGraph(), name="agent")
+        fa = app.function_app
+        fa.functions_bindings = {}
+        names = {f.get_function_name() for f in fa.get_functions()}
+        assert {
+            "aflg_health",
+            "aflg_health_details",
+            "aflg_agent_invoke",
+            "aflg_agent_stream",
+        } <= names
+
+    def test_stream_disabled_skips_stream_route(self) -> None:
+        app = StreamingLangGraphApp()
+        app.register(graph=FakeSyncGraph(), name="agent", stream=False)
+        fa = app.function_app
+        fa.functions_bindings = {}
+        names = {f.get_function_name() for f in fa.get_functions()}
+        assert "aflg_agent_invoke" in names
+        assert "aflg_agent_stream" not in names
+
+    def test_invoke_only_graph_skips_stream_route(self) -> None:
+        app = StreamingLangGraphApp()
+        app.register(graph=FakeInvokeOnlyGraph(), name="agent")
+        fa = app.function_app
+        fa.functions_bindings = {}
+        names = {f.get_function_name() for f in fa.get_functions()}
+        assert "aflg_agent_invoke" in names
+
+    def test_function_app_cached(self) -> None:
+        app = StreamingLangGraphApp()
+        app.register(graph=FakeSyncGraph(), name="agent")
+        assert app.function_app is app.function_app
+
+    def test_register_invalidates_cache(self) -> None:
+        app = StreamingLangGraphApp()
+        app.register(graph=FakeSyncGraph(), name="a")
+        first = app.function_app
+        app.register(graph=FakeSyncGraph(), name="b")
+        assert app.function_app is not first
+
+    def test_per_graph_auth_override(self) -> None:
+        app = StreamingLangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=FakeSyncGraph(), name="pub", auth_level=func.AuthLevel.ANONYMOUS)
+        fa = app.function_app
+        fa.functions_bindings = {}
+        for f in fa.get_functions():
+            if f.get_function_name() == "aflg_pub_invoke":
+                assert f.get_trigger().auth_level == func.AuthLevel.ANONYMOUS  # type: ignore[union-attr]
+                break
+        else:
+            pytest.fail("invoke function not found")
+
+    def test_health_details_defaults_to_app_auth(self) -> None:
+        app = StreamingLangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        assert app._resolved_health_details_auth_level == func.AuthLevel.FUNCTION
+
+    def test_health_details_explicit_auth(self) -> None:
+        app = StreamingLangGraphApp(
+            auth_level=func.AuthLevel.FUNCTION,
+            health_details_auth_level=func.AuthLevel.ANONYMOUS,
+        )
+        assert app._resolved_health_details_auth_level == func.AuthLevel.ANONYMOUS
+
+
+# ------------------------------------------------------------------
+# _handle_invoke
+# ------------------------------------------------------------------
+
+
+def _app_with(graph: Any, name: str = "agent", **kwargs: Any) -> tuple[StreamingLangGraphApp, Any]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        app = StreamingLangGraphApp(**kwargs)
+    app.register(graph=graph, name=name)
+    reg = app._registrations[name]
+    return app, reg
+
+
+def _lock(app: StreamingLangGraphApp) -> Any:
+    """Return the app's thread lock, narrowed from ``Optional`` for the type checker."""
+    assert app.thread_lock is not None
+    return app.thread_lock
+
+
+
+class TestHandleInvoke:
+    async def test_sync_success(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        observer = RecordingObserver()
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}}), reg, False, JSONResponse, observer, _lock(app)
+        )
+        assert resp.status_code == 200
+        assert observer.events == ["started", "completed"]
+
+    async def test_async_success(self) -> None:
+        app, reg = _app_with(FakeAsyncGraph())
+        observer = RecordingObserver()
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}}), reg, True, JSONResponse, observer, _lock(app)
+        )
+        assert resp.status_code == 200
+        assert "completed" in observer.events
+
+    async def test_invalid_json(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        observer = RecordingObserver()
+        resp = await app._handle_invoke(
+            FakeRequest(raw=b"{bad"), reg, False, JSONResponse, observer, _lock(app)
+        )
+        assert resp.status_code == 400
+        assert observer.events == ["rejected:invalid_request"]
+
+    async def test_validation_error(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        resp = await app._handle_invoke(
+            FakeRequest({"input": "bad"}),
+            reg,
+            False,
+            JSONResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 422
+
+    async def test_invalid_config(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}, "config": {"configurable": "nope"}}),
+            reg,
+            False,
+            JSONResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 400
+
+    async def test_lock_contention(self) -> None:
+        lock = InProcessThreadLock()
+        app, reg = _app_with(FakeSyncGraph(checkpointer=object()))
+        app.thread_lock = lock
+        lock.acquire("agent", "t1")  # pre-hold
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}, "config": {"configurable": {"thread_id": "t1"}}}),
+            reg,
+            False,
+            JSONResponse,
+            NoOpRunObserver(),
+            lock,
+        )
+        assert resp.status_code == 409
+
+    async def test_graph_execution_error(self) -> None:
+        app, reg = _app_with(FailingInvokeGraph())
+        observer = RecordingObserver()
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}}), reg, False, JSONResponse, observer, _lock(app)
+        )
+        assert resp.status_code == 500
+        assert "failed" in observer.events
+
+    async def test_lock_acquired_and_released_on_success(self) -> None:
+        lock = RecordingLock()
+        app, reg = _app_with(FakeSyncGraph(checkpointer=object()))
+        app.thread_lock = lock
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}, "config": {"configurable": {"thread_id": "t1"}}}),
+            reg,
+            False,
+            JSONResponse,
+            NoOpRunObserver(),
+            lock,
+        )
+        assert resp.status_code == 200
+        assert lock.acquired == [("agent", "t1")]
+        assert lock.released == [("agent", "t1", "tok")]
+
+
+# ------------------------------------------------------------------
+# _handle_stream
+# ------------------------------------------------------------------
+
+
+class TestHandleStream:
+    async def test_streaming_unsupported(self) -> None:
+        app, reg = _app_with(FakeInvokeOnlyGraph())
+        observer = RecordingObserver()
+        resp = await app._handle_stream(
+            FakeRequest({"input": {}}),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            observer,
+            _lock(app),
+        )
+        assert resp.status_code == 501
+        assert observer.events == ["rejected:streaming_unsupported"]
+
+    async def test_invalid_json(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        resp = await app._handle_stream(
+            FakeRequest(raw=b"{bad"),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 400
+
+    async def test_invalid_config(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        resp = await app._handle_stream(
+            FakeRequest({"input": {}, "config": {"configurable": "nope"}}),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 400
+
+    async def test_lock_contention(self) -> None:
+        lock = InProcessThreadLock()
+        app, reg = _app_with(FakeSyncGraph(checkpointer=object()))
+        app.thread_lock = lock
+        lock.acquire("agent", "t1")
+        resp = await app._handle_stream(
+            FakeRequest({"input": {}, "config": {"configurable": {"thread_id": "t1"}}}),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            NoOpRunObserver(),
+            lock,
+        )
+        assert resp.status_code == 409
+
+    async def test_success_streams_frames(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        observer = RecordingObserver()
+        resp = await app._handle_stream(
+            FakeRequest({"input": {}}),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            observer,
+            _lock(app),
+        )
+        assert resp.media_type == "text/event-stream"
+        assert resp.headers["X-Accel-Buffering"] == "no"
+        frames = await _read_stream_response(resp)
+        assert any(f.startswith("event: data\n") for f in frames)
+        assert frames[-1] == "event: end\ndata: {}\n\n"
+        # started emitted before headers; completed emitted as the stream drains.
+        assert observer.events == ["started", "completed"]
+
+    async def test_async_success_streams_frames(self) -> None:
+        app, reg = _app_with(FakeAsyncGraph())
+        resp = await app._handle_stream(
+            FakeRequest({"input": {}}),
+            reg,
+            True,
+            JSONResponse,
+            StreamingResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        frames = await _read_stream_response(resp)
+        assert len([f for f in frames if f.startswith("event: data\n")]) == 3
+
+
+class VersionGraph:
+    """Graph whose stream/invoke accept a ``version`` kwarg (via **kwargs)."""
+
+    checkpointer = None
+
+    def invoke(
+        self, input: dict[str, Any], config: dict[str, Any] | None = None, **kw: Any
+    ) -> dict[str, Any]:
+        return {"ok": True, "version": kw.get("version")}
+
+    def stream(
+        self,
+        input: dict[str, Any],
+        config: dict[str, Any] | None = None,
+        stream_mode: str = "values",
+        **kw: Any,
+    ) -> Iterator[dict[str, Any]]:
+        yield {"version": kw.get("version")}
+
+
+def _user_fn(app: StreamingLangGraphApp, fn_name: str) -> Any:
+    fa = app.function_app
+    fa.functions_bindings = {}
+    for fn in fa.get_functions():
+        if fn.get_function_name() == fn_name:
+            return fn.get_user_function()
+    raise AssertionError(f"function {fn_name!r} not found")
+
+
+class TestWiredHandlers:
+    """Cover the health + per-graph closures wired inside ``_build_function_app``."""
+
+    async def test_health(self) -> None:
+        app, _ = _app_with(FakeSyncGraph())
+        resp = await _user_fn(app, "aflg_health")(FakeRequest())
+        assert json.loads(bytes(resp.body)) == {"status": "ok"}
+
+    async def test_health_details(self) -> None:
+        app, _ = _app_with(FakeSyncGraph(checkpointer=object()))
+        resp = await _user_fn(app, "aflg_health_details")(FakeRequest())
+        body = json.loads(bytes(resp.body))
+        assert body["status"] == "ok"
+        assert body["graphs"][0]["name"] == "agent"
+        assert body["graphs"][0]["has_checkpointer"] is True
+
+    async def test_wired_invoke(self) -> None:
+        app, _ = _app_with(FakeSyncGraph())
+        resp = await _user_fn(app, "aflg_agent_invoke")(FakeRequest({"input": {}}))
+        assert resp.status_code == 200
+
+    async def test_wired_stream(self) -> None:
+        app, _ = _app_with(FakeSyncGraph())
+        resp = await _user_fn(app, "aflg_agent_stream")(FakeRequest({"input": {}}))
+        frames = await _read_stream_response(resp)
+        assert frames[-1] == "event: end\ndata: {}\n\n"
+
+
+class TestVersionAndThreadIdBranches:
+    async def test_invoke_version_forwarded(self) -> None:
+        app, reg = _app_with(VersionGraph())
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}, "version": "v2"}),
+            reg,
+            False,
+            JSONResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 200
+
+    async def test_invoke_version_rejected(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}, "version": "v2"}),
+            reg,
+            False,
+            JSONResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 422
+
+    async def test_stream_version_rejected(self) -> None:
+        app, reg = _app_with(FakeSyncGraph())
+        resp = await app._handle_stream(
+            FakeRequest({"input": {}, "version": "v2"}),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 422
+
+    async def test_invoke_invalid_thread_id(self) -> None:
+        app, reg = _app_with(FakeSyncGraph(checkpointer=object()))
+        resp = await app._handle_invoke(
+            FakeRequest({"input": {}, "config": {"configurable": {"thread_id": "bad\x01id"}}}),
+            reg,
+            False,
+            JSONResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 400
+
+
+class TestExtraPaths:
+    async def test_stream_success_with_lock(self) -> None:
+        lock = RecordingLock()
+        app, reg = _app_with(FakeSyncGraph(checkpointer=object()))
+        app.thread_lock = lock
+        resp = await app._handle_stream(
+            FakeRequest({"input": {}, "config": {"configurable": {"thread_id": "t1"}}}),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            NoOpRunObserver(),
+            lock,
+        )
+        frames = await _read_stream_response(resp)
+        assert frames[-1] == "event: end\ndata: {}\n\n"
+        assert lock.acquired == [("agent", "t1")]
+        assert lock.released == [("agent", "t1", "tok")]
+
+    def test_explicit_lock_and_observer_preserved(self) -> None:
+        lock = InProcessThreadLock()
+        observer = RecordingObserver()
+        app = StreamingLangGraphApp(thread_lock=lock, observer=observer)
+        assert app.thread_lock is lock
+        assert app.observer is observer
+
+    async def test_stream_input_structure_rejected(self) -> None:
+        app, reg = _app_with(FakeSyncGraph(), max_input_depth=1)
+        resp = await app._handle_stream(
+            FakeRequest({"input": {"a": {"b": {"c": {}}}}}),
+            reg,
+            False,
+            JSONResponse,
+            StreamingResponse,
+            NoOpRunObserver(),
+            _lock(app),
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- Add `StreamingLangGraphApp` — a separate app type that serves graphs over the FastAPI/ASGI transport (`azurefunctions-extensions-http-fastapi`, runtime 4.34.1+), flushing each SSE `event: data` frame **as the graph produces it** for genuine incremental delivery.
- Leave the classic `LangGraphApp` contract **unchanged** and still the default; true streaming is gated behind a new `streaming` extra and converts the whole app to ASGI (cannot be mixed with classic routes).
- Replace the buffered `max_stream_response_bytes` guard with a `max_stream_events` frame-count cap, since a true stream is never buffered.
- Lazy `StreamingLangGraphApp` export, runnable `examples/true_streaming_agent/` (with a `curl -N` walkthrough), deterministic unit tests (99% coverage of `streaming.py`), and docs across README / COMPATIBILITY / examples.

## Testing
- `hatch run pytest --cov` — all pass, total coverage **96.46%** (>=95% gate), `streaming.py` at 99%.
- `hatch run ruff` clean; `hatch run mypy src tests` clean (strict).

## Notes
- Real-Azure incremental-arrival E2E certification is **deferred** (local/deterministic proof only in this PR).

Closes #406