### PR TITLE
ci(deps): certify azure-functions 2.x on Py 3.14 and draft Flex Consumption e2e

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -255,18 +255,30 @@ jobs:
 
 
   azure-functions-2x:
-    name: azure-functions 2.x compat (Py 3.13)
+    name: azure-functions 2.x compat (Py ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # azure-functions 2.x declares Requires-Python >=3.13, so this proof
+        # lane runs on the Azure-GA interpreters that can host the 2.x worker:
+        # Python 3.13 and 3.14 (both GA for Azure Functions; #350). 3.14 is a
+        # non-blocking cell (continue-on-error below) only because transitive
+        # dependency wheels for 3.14 may still be landing - the azure-functions
+        # 2.x surface itself is certified as GA, not exploratory.
+        python-version: ["3.13", "3.14"]
+    # 3.14 is informational until the full transitive-dependency wheel set is
+    # published for 3.14; a red 3.14 cell must not block a PR. 3.13 stays
+    # blocking.
+    continue-on-error: ${{ matrix.python-version == '3.14' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up Python 3.13
-        # azure-functions 2.x declares Requires-Python >=3.13, so this proof
-        # lane must run on 3.13 (3.14 stays exploratory until Azure supports it).
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Build wheel
         # Issue #350 requires proving 2.x against a WHEEL-installed build, not an

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -20,6 +20,14 @@ on:
         description: Expected package version (must match source __version__)
         required: false
         type: string
+      certify_2x:
+        description: >-
+          Also certify the azure-functions 2.x runtime on Flex Consumption
+          (Python 3.13). Off by default; the 1.x Linux Consumption path is the
+          release-gating certification (#350).
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -168,10 +176,158 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # ── azure-functions 2.x certification (Flex Consumption, Python 3.13) ──────
+  # Opt-in via the `certify_2x` dispatch input. This is the real-Azure proof for
+  # #350: Linux Consumption (Y1) caps at Python 3.12, so the 2.x worker must be
+  # certified on Flex Consumption (Py 3.13+). It is INTENTIONALLY not wired into
+  # the publish gate (publish-pypi.yml verify-azure-certification consumes the
+  # 1.x `azure-cert` artifact only) — the pyproject `<2.0.0` cap must NOT be
+  # raised until this lane has been dispatched green at least once.
+  #
+  # STATUS: unverified scaffold (infra/flex.bicep has never been deployed). The
+  # first successful dispatch validates both this job and the Flex Bicep.
+  deploy_and_test_2x:
+    name: Deploy & Test (azure-functions 2.x / Flex / Py 3.13)
+    runs-on: ubuntu-latest
+    if: ${{ inputs.certify_2x }}
+    outputs:
+      resource_group: ${{ steps.names.outputs.rg }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Compute resource names
+        id: names
+        run: |
+          RUN="${GITHUB_RUN_ID}${GITHUB_RUN_ATTEMPT}"
+          RG="rg-af-e2e-${REPO_SHORT}-2x-${RUN}"
+          APP="af-e2e-${REPO_SHORT}-2x-${RUN}"
+          # Storage name: lowercase alphanumeric, max 24 chars
+          ST="stafe2e2x${RUN}"
+          ST="${ST:0:24}"
+          echo "rg=${RG}"   >> "$GITHUB_OUTPUT"
+          echo "app=${APP}" >> "$GITHUB_OUTPUT"
+          echo "st=${ST}"   >> "$GITHUB_OUTPUT"
+
+      - name: Azure login (OIDC)
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Create Resource Group
+        run: |
+          az group create \
+            --name "${{ steps.names.outputs.rg }}" \
+            --location "$AZURE_LOCATION" \
+            --tags purpose=e2e repo=azure-functions-langgraph runtime=2x run="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+      - name: Deploy Flex Consumption infra (Bicep)
+        run: |
+          az deployment group create \
+            --resource-group "${{ steps.names.outputs.rg }}" \
+            --template-file infra/flex.bicep \
+            --parameters \
+                location="$AZURE_LOCATION" \
+                functionAppName="${{ steps.names.outputs.app }}" \
+                storageName="${{ steps.names.outputs.st }}" \
+                pythonVersion="3.13"
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install Azure Functions Core Tools
+        run: |
+          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
+          sudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
+          sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
+          sudo apt-get update
+          sudo apt-get install -y azure-functions-core-tools-4
+
+      - name: Bundle candidate wheel + force azure-functions 2.x into the payload
+        run: |
+          # Build a wheel from THIS ref and inject it into the deployed app's
+          # requirements so the Azure remote build runs the candidate source.
+          # The wheel's dependency contract still caps azure-functions <2.0.0,
+          # so append an explicit 2.x override AFTER it — this lane exists to
+          # PROVE the 2.x worker path, mirroring the ci-test.yml 2.x compat lane.
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+          WHEEL=$(ls dist/azure_functions_langgraph-*.whl | head -n1)
+          echo "Built candidate wheel: $WHEEL"
+          mkdir -p examples/e2e_app/wheels
+          cp "$WHEEL" examples/e2e_app/wheels/
+          BASENAME=$(basename "$WHEEL")
+          echo "./wheels/${BASENAME}" >> examples/e2e_app/requirements.txt
+          echo "azure-functions>=2,<3" >> examples/e2e_app/requirements.txt
+          echo "---- examples/e2e_app/requirements.txt ----"
+          cat examples/e2e_app/requirements.txt
+
+      - name: Install library from source + test deps
+        run: |
+          pip install -e ".[dev]"
+          pip install requests
+
+      - name: Publish function app
+        working-directory: examples/e2e_app
+        timeout-minutes: 40
+        run: |
+          func azure functionapp publish "${{ steps.names.outputs.app }}" --python --build remote
+
+      - name: Run e2e tests
+        env:
+          E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+        run: |
+          # Native LangGraph routes only (health/invoke/stream); the two-app
+          # single-writer contention suite (App B) is not part of the 2.x
+          # runtime certification.
+          pytest tests/e2e -v -m e2e -o addopts="" -k "not app_b and not two_app"
+
+      - name: Record 2.x certification
+        run: |
+          SHA=$(git rev-parse HEAD)
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_langgraph/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested certification version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          mkdir -p cert-2x
+          cat > cert-2x/certification.json <<EOF
+          {
+            "package": "azure-functions-langgraph",
+            "version": "$VERSION",
+            "commit": "$SHA",
+            "ref": "${{ inputs.ref || github.ref }}",
+            "workflow": "e2e-azure.yml",
+            "job": "deploy_and_test_2x",
+            "runtime": "azure-functions-2x",
+            "hosting_plan": "FlexConsumption",
+            "python": "3.13",
+            "run_id": "${{ github.run_id }}",
+            "result": "success",
+            "certified_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat cert-2x/certification.json
+
+      - name: Upload 2.x certification record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: azure-cert-2x
+          path: cert-2x/
+          if-no-files-found: error
+          retention-days: 30
+
   cleanup:
     name: Cleanup Azure Resources
     runs-on: ubuntu-latest
-    needs: [deploy_and_test]
+    needs: [deploy_and_test, deploy_and_test_2x]
     if: always()
     steps:
       - name: Azure login (OIDC)
@@ -189,4 +345,14 @@ jobs:
             az group delete --name "$RG" --yes --no-wait
           else
             echo "No resource group to delete."
+          fi
+
+      - name: Delete 2.x Resource Group
+        run: |
+          RG_2X="${{ needs.deploy_and_test_2x.outputs.resource_group }}"
+          if [ -n "$RG_2X" ]; then
+            echo "Deleting 2.x resource group: $RG_2X"
+            az group delete --name "$RG_2X" --yes --no-wait
+          else
+            echo "No 2.x resource group to delete."
           fi

--- a/infra/flex.bicep
+++ b/infra/flex.bicep
@@ -1,0 +1,138 @@
+// infra/flex.bicep
+// Flex Consumption infra for the azure-functions 2.x real-Azure certification
+// lane (#350). Creates: Storage Account + Flex Consumption plan + Function App
+// (Flex Consumption / Linux / Python 3.13+), which is the hosting model Azure
+// requires for Python 3.13/3.14 — Linux Consumption (Y1, see infra/main.bicep)
+// caps at Python 3.12 and therefore cannot host the azure-functions 2.x worker.
+//
+// STATUS: unverified scaffold. This template has NOT yet been deployed to real
+// Azure; it exists so the 2.x certification job in e2e-azure.yml has a concrete
+// target the first time it is dispatched. Treat the first real dispatch as the
+// validation of this file, and do NOT raise the pyproject `azure-functions`
+// `<2.0.0` cap until that dispatch is green (#350 acceptance).
+//
+// The certified example (examples/e2e_app) exercises the native LangGraph
+// routes (/api/health, /api/graphs/<name>/invoke, /api/graphs/<name>/stream),
+// which need only AzureWebJobsStorage. Platform-compatible routes are out of
+// scope for this baseline 2.x runtime certification, mirroring infra/main.bicep.
+//
+// Usage:
+//   az deployment group create -g <rg> -f infra/flex.bicep \
+//     -p functionAppName=<name> storageName=<name> location=<loc> \
+//        pythonVersion=3.13
+
+@description('Azure region for all resources. Must be a region that offers Flex Consumption.')
+param location string = resourceGroup().location
+
+@description('Name of the Function App (must be globally unique).')
+param functionAppName string
+
+@description('Name of the Storage Account (3-24 lowercase alphanumeric).')
+param storageName string
+
+@description('Python major.minor version for the Flex Consumption runtime (3.13 or 3.14).')
+@allowed([
+  '3.13'
+  '3.14'
+])
+param pythonVersion string = '3.13'
+
+@description('Blob container used by Flex Consumption for the one-deploy deployment package.')
+param deploymentContainerName string = 'deploymentpackage'
+
+@description('Instance memory (MB) for the Flex Consumption plan.')
+@allowed([
+  512
+  2048
+  4096
+])
+param instanceMemoryMB int = 2048
+
+@description('Maximum instance count for the Flex Consumption plan.')
+param maximumInstanceCount int = 40
+
+// ── Storage Account ────────────────────────────────────────────────────────
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}
+
+var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+
+// ── Deployment container (Flex Consumption one-deploy package store) ────────
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: deploymentContainerName
+}
+
+// ── Flex Consumption Hosting Plan ──────────────────────────────────────────
+resource hostingPlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: '${functionAppName}-flexplan'
+  location: location
+  sku: {
+    name: 'FC1'
+    tier: 'FlexConsumption'
+  }
+  kind: 'functionapp'
+  properties: {
+    reserved: true
+  }
+}
+
+// ── Function App (Flex Consumption) ────────────────────────────────────────
+// Flex Consumption configures the runtime through `functionAppConfig`
+// (deployment + runtime + scaleAndConcurrency) rather than
+// `siteConfig.linuxFxVersion` used by the Y1 Linux Consumption template. The
+// worker runtime is declared here, so FUNCTIONS_WORKER_RUNTIME is intentionally
+// NOT set as an app setting.
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp,linux'
+  properties: {
+    serverFarmId: hostingPlan.id
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: '${storageAccount.properties.primaryEndpoints.blob}${deploymentContainerName}'
+          authentication: {
+            type: 'StorageAccountConnectionStringSecret'
+            storageAccountConnectionStringName: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+          }
+        }
+      }
+      scaleAndConcurrency: {
+        maximumInstanceCount: maximumInstanceCount
+        instanceMemoryMB: instanceMemoryMB
+      }
+      runtime: {
+        name: 'python'
+        version: pythonVersion
+      }
+    }
+    siteConfig: {
+      appSettings: [
+        { name: 'AzureWebJobsStorage', value: storageConnectionString }
+        { name: 'DEPLOYMENT_STORAGE_CONNECTION_STRING', value: storageConnectionString }
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+      ]
+    }
+    httpsOnly: true
+  }
+}
+
+// ── Outputs ────────────────────────────────────────────────────────────────
+output functionAppName string = functionApp.name
+output defaultHostName string = functionApp.properties.defaultHostName


### PR DESCRIPTION
## Summary
Advances the **CI-authoring** portion of azure-functions 2.x certification (#350) **without touching the pyproject `<2.0.0` cap**.

- **`ci-test.yml`** — expand the `azure-functions 2.x compat` lane to a matrix over Python **3.13 and 3.14** (both Azure Functions GA). 3.14 is a non-blocking cell (`continue-on-error`) only because its transitive-dependency wheels may still be landing; the 2.x surface itself is GA, not exploratory.
- **`e2e-azure.yml`** — add an opt-in `certify_2x` dispatch input and a `deploy_and_test_2x` job that certifies the 2.x worker on **Flex Consumption (Python 3.13)** — the hosting model Azure requires above the Linux Consumption Python 3.12 ceiling. Deliberately **not** wired into the publish gate; records a separate `azure-cert-2x` artifact. Cleanup extended to tear down its resource group.
- **`infra/flex.bicep`** — Flex Consumption target (FC1 plan + `functionAppConfig` runtime) for the 2.x lane. Compiles cleanly (`az bicep build`).

## What this deliberately does NOT do
- **Does not raise the `azure-functions <2.0.0` cap.** Per the issue and Oracle-validated sequencing, the cap stays until a real-Azure 2.x certification is green.
- The `deploy_and_test_2x` job + `flex.bicep` are an **unverified scaffold** — the first real dispatch (`gh workflow run e2e-azure.yml -f certify_2x=true`) validates them.

## Validation
- YAML valid; `tools/lint_release_workflows.py` and `tools/lint_workflow_pins.py` pass (canonical action SHAs preserved).
- `az bicep build infra/flex.bicep` — clean.

Refs #350