### PR TITLE
feat: optional Durable Functions async run lifecycle (#408)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -131,6 +131,23 @@ Derived from `_preflight_run_create()` in `platform/_common.py`.
 | `threads.update_state` | ✅ Full | Requires the graph to satisfy `UpdatableStateGraph`. |
 | `threads.get_history` | ✅ Full | Requires `StateHistoryGraph`. Filtering by `metadata`, `before`, `checkpoint`, and `limit` is supported. |
 
+### Durable async run lifecycle (experimental, non-SDK)
+
+Independent of the Platform-compat SDK layer, `LangGraphApp(async_runs="durable")`
+adds a Durable Functions-backed async run control plane (`durable` extra). These
+are **native** routes, not `langgraph-sdk` calls:
+
+| Route | Support | Notes |
+|---|---|---|
+| `POST /api/graphs/{name}/runs` | ✅ | Starts a Durable orchestration; returns `202` with `run_id` + `pending`. Unknown graph → `404`; oversized/invalid body → `400`. |
+| `GET /api/runs/{run_id}` | ✅ | Normalized status (`pending`/`running`/`completed`/`failed`/`canceled`). Unknown id → `404`. |
+| `POST /api/runs/{run_id}/cancel` | ✅ | Terminates the orchestration. |
+
+Graph user code runs only in a Durable **activity**, never the orchestrator, so
+replay determinism holds. Durable history does **not** replace LangGraph
+checkpoints. See the README "Durable async run lifecycle" section and
+[`examples/durable_async_agent/`](examples/durable_async_agent/).
+
 ### Webhooks, cron, store
 
 | Area | Support |

--- a/README.md
+++ b/README.md
@@ -449,6 +449,39 @@ HTTP runs in your observer. See
 [`examples/service_bus_agent/`](examples/service_bus_agent/) for a full wiring.
 
 
+### Durable async run lifecycle (experimental)
+
+For long-running graphs, opt into an **experimental** Durable Functions-backed
+async run control plane with `LangGraphApp(async_runs="durable")`. This adds a
+create / poll / cancel HTTP surface on top of the classic invoke/stream routes:
+
+```python
+from azure_functions_langgraph import LangGraphApp
+
+app = LangGraphApp(async_runs="durable")  # requires the `durable` extra
+app.register(graph=graph, name="my_agent")
+func_app = app.function_app
+```
+
+```bash
+pip install "azure-functions-langgraph[durable]"
+```
+
+| Route | Purpose |
+|---|---|
+| `POST /api/graphs/{name}/runs` | Start a run — returns `202` with a `run_id` and `pending` status |
+| `GET /api/runs/{run_id}` | Poll normalized run status (`pending` / `running` / `completed` / `failed` / `canceled`) |
+| `POST /api/runs/{run_id}/cancel` | Terminate an in-flight run |
+
+The graph executes inside a Durable **activity**, never the orchestrator, so
+Durable replay determinism is preserved — no LLM, tool, network, clock, random,
+or graph user code runs in the orchestrator. Durable history is **not** a
+replacement for LangGraph checkpoints; reuse a checkpointer for conversation
+state as usual. Durable dependencies stay optional behind the `durable` extra.
+See [`examples/durable_async_agent/`](examples/durable_async_agent/) for a full
+create → poll → result → cancel walkthrough.
+
+
 ### Per-graph auth
 
 Override app-level auth settings per graph:

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -193,13 +193,30 @@ Graph execution is synchronous from the HTTP handler perspective.
 `graph.invoke()` and `graph.stream()` run until completion (or failure).
 
 - No package-level timeout wrapper is applied around graph calls.
-- No built-in cancellation endpoint is provided for long-running graph runs.
+- No package-level timeout wrapper is applied around graph calls on the synchronous HTTP path. For a built-in async run lifecycle with a cancellation endpoint, see "Async runs via Durable Functions" below.
 
 ⚠️ If a graph exceeds platform timeout, the request fails at the Functions host boundary.
 
 ⚠️ **HTTP response ceiling**: Azure Functions enforces a hard **230-second** limit on HTTP response time regardless of `functionTimeout`.
 Graph invocations that exceed 230 seconds will fail with a gateway timeout even if `functionTimeout` allows longer execution.
 For workloads approaching this limit, consider async patterns (queue trigger + status polling) instead of synchronous HTTP.
+
+### Async runs via Durable Functions (experimental)
+
+For workloads that exceed the synchronous HTTP ceiling, opt into the built-in
+Durable Functions-backed async run lifecycle with
+`LangGraphApp(async_runs="durable")` (requires the `durable` extra). This adds a
+create / poll / cancel control plane so callers no longer hold an HTTP
+connection open for the duration of the run:
+
+- `POST /api/graphs/{name}/runs` — start a run, returns `202` with a `run_id`
+- `GET /api/runs/{run_id}` — poll normalized status
+- `POST /api/runs/{run_id}/cancel` — terminate an in-flight run
+
+The graph executes inside a Durable **activity**, never the orchestrator, so
+replay determinism is preserved. Durable history is not a replacement for
+LangGraph checkpoints. See the README "Durable async run lifecycle" section and
+[`examples/durable_async_agent/`](../examples/durable_async_agent/).
 
 ### Configure timeout explicitly
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@
 | Maintenance timer | [`maintenance_timer`](maintenance_timer/) | Timer Trigger that resets stale run locks on `AzureTableThreadStore`. |
 | Service Bus trigger | [`service_bus_agent`](service_bus_agent/) | Drive a graph from an Azure Service Bus **queue** message via `register_service_bus` — one `invoke` per message, exceptions not swallowed. |
 | True HTTP streaming | [`true_streaming_agent`](true_streaming_agent/) | Opt into **true** incremental SSE with `StreamingLangGraphApp` — each `event: data` frame flushed as the graph produces it, over the FastAPI/ASGI transport (`streaming` extra, runtime 4.34.1+). |
+| Durable async runs | [`durable_async_agent`](durable_async_agent/) | Opt into an **experimental** Durable Functions-backed async run lifecycle with `LangGraphApp(async_runs="durable")` — `POST graphs/{name}/runs` returns `202` with a run id, `GET runs/{run_id}` polls status, `POST runs/{run_id}/cancel` terminates. Graph runs in a Durable **activity** (never the orchestrator). `durable` extra. |
 
 ## Conventions
 
@@ -62,3 +63,4 @@ Utility examples (e.g. `maintenance_timer`, `local_curl`) may omit `graph.py` wh
 - **Recovering orphaned run locks automatically?** → `maintenance_timer`
 - **Driving a graph from Service Bus messages (background jobs, decoupled pipelines)?** → `service_bus_agent`
 - **Need true incremental token streaming (not buffered SSE)?** → `true_streaming_agent`
+- **Need long-running async runs with a poll/cancel lifecycle (Durable Functions)?** → `durable_async_agent`

--- a/examples/durable_async_agent/README.md
+++ b/examples/durable_async_agent/README.md
@@ -1,0 +1,151 @@
+# Durable Async Agent — Long-Running Runs with Durable Functions
+
+This example serves a LangGraph graph as an **asynchronous run lifecycle**
+backed by [Azure Durable Functions](https://learn.microsoft.com/azure/azure-functions/durable/),
+via `LangGraphApp(async_runs="durable")` (issue #408).
+
+Instead of a single synchronous `POST /invoke` that blocks until the graph
+finishes, callers **start** a run, **poll** it, and optionally **cancel** it —
+the pattern you want when a run may outlive an HTTP request timeout, or when the
+caller wants to fire-and-follow rather than block.
+
+> **Not "unlimited" and not a checkpoint replacement.** This is an async run
+> lifecycle over the existing graph runtime. Durable history is **not** a
+> replacement for LangGraph checkpoints — configure a checkpointer as usual for
+> conversation state. The Durable orchestrator only sequences a single activity
+> that runs your graph; it does not re-express your graph's nodes/edges as
+> Durable steps.
+
+## How it works
+
+```
+POST /api/graphs/{name}/runs   ──►  202  { "run_id": "...", "status": "pending" }
+        │  (Durable: start_new orchestration, instance_id == run_id)
+        ▼
+   orchestrator  ──yields──►  execute_langgraph_run  activity  ──►  graph.invoke()
+        │                          (all user/graph code runs HERE, not in the
+        │                           orchestrator, so replay stays deterministic)
+        ▼
+GET  /api/runs/{run_id}        ──►  200  { "status": "running" | "success" | ... , "output": ... }
+POST /api/runs/{run_id}/cancel ──►  202  { "status": "cancelled" }
+```
+
+`run_id == Durable instance_id == platform run_id` — one stable id, no second
+run registry. Durable instance state is the single source of truth for status.
+
+Normalized statuses returned by `GET /runs/{run_id}`:
+
+| status | meaning |
+| --- | --- |
+| `pending` | run accepted, orchestration not yet scheduled |
+| `running` | orchestration/activity in flight |
+| `success` | graph completed; `output.result` holds the graph output |
+| `error` | graph raised, or the run was rejected (e.g. thread-lock contention) |
+| `cancelled` | run was terminated via the cancel endpoint |
+
+## Files
+
+- `graph.py` — the compiled graph (a deterministic `work → respond` graph with a
+  tiny artificial delay so `pending`/`running` is observable)
+- `function_app.py` — `LangGraphApp(async_runs="durable")` wiring
+- `host.json`, `local.settings.json.example`, `requirements.txt`
+
+## Requirements
+
+The Durable async surface is gated behind the optional `durable` extra:
+
+```bash
+pip install "azure-functions-langgraph[durable]"
+```
+
+Durable Functions needs a storage account for its task hub — locally this is
+[Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite)
+via `AzureWebJobsStorage=UseDevelopmentStorage=true` (already set in
+`local.settings.json.example`).
+
+## Local development
+
+```bash
+cp local.settings.json.example local.settings.json
+
+pip install -r requirements.txt
+
+# Start Azurite in another terminal (or use the VS Code extension):
+#   npm install -g azurite && azurite
+
+func start
+```
+
+### Start a run
+
+```bash
+curl -s -X POST http://localhost:7071/api/graphs/durable_async_agent/runs \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"messages": [{"role": "human", "content": "Hello!"}]}}'
+```
+
+```json
+{"run_id": "9f3c...e21", "status": "pending"}
+```
+
+### Poll the run
+
+```bash
+curl -s http://localhost:7071/api/runs/9f3c...e21
+```
+
+```json
+{"run_id": "9f3c...e21", "status": "running", "output": null}
+```
+
+…then, once complete:
+
+```json
+{
+  "run_id": "9f3c...e21",
+  "status": "success",
+  "output": {
+    "run_id": "9f3c...e21",
+    "activity_status": "success",
+    "result": {"messages": [
+      {"role": "human", "content": "Hello!"},
+      {"role": "assistant", "content": "Processed: Hello!"}
+    ]},
+    "error": null
+  }
+}
+```
+
+### Cancel a run
+
+```bash
+curl -s -X POST http://localhost:7071/api/runs/9f3c...e21/cancel
+```
+
+```json
+{"run_id": "9f3c...e21", "status": "cancelled"}
+```
+
+## Thread state and locking
+
+Pass `thread_id` (or `config.configurable.thread_id`) in the create-run body to
+run against a checkpointed thread. When the graph has a checkpointer and a
+`thread_id` is present, the app-level `thread_lock` guards the run — concurrent
+runs for the same thread do not mutate checkpoints concurrently; a contended run
+comes back with `status: "error"` (rejected) rather than corrupting state.
+
+## Telemetry
+
+Runs carry a `trigger_type="durable"` correlation field on the `RunContext`, so
+durable async runs are distinguishable from HTTP invoke/stream runs in your
+observer. Input/output payloads are **never** included in telemetry.
+
+## Scope & caveats (experimental)
+
+- Activities are **at-least-once** — Durable may re-run an activity on host
+  restart. Graph runs should be idempotent (a checkpointer makes replays
+  converge on the same thread state).
+- This example runs one activity per run. It does **not** re-express the graph
+  topology as Durable activities — that is intentionally out of scope (see the
+  sibling `azure-functions-durable-graph-python` package for a manifest-first
+  Durable graph runtime).

--- a/examples/durable_async_agent/function_app.py
+++ b/examples/durable_async_agent/function_app.py
@@ -1,0 +1,35 @@
+"""Durable async agent — Azure Functions entry point.
+
+Exposes a LangGraph graph as an **asynchronous** run lifecycle backed by Azure
+Durable Functions (issue #408). Instead of blocking on a synchronous
+``/invoke``, callers:
+
+1. ``POST /api/graphs/durable_async_agent/runs`` — start a run, get ``202`` with
+   a ``run_id`` and ``status: "pending"``.
+2. ``GET  /api/runs/{run_id}`` — poll the normalized status
+   (``pending`` → ``running`` → ``success`` / ``error`` / ``cancelled``); the
+   ``output`` appears once the run completes.
+3. ``POST /api/runs/{run_id}/cancel`` — terminate an in-flight run.
+
+The Durable orchestrator stays deterministic — all graph execution happens in a
+Durable activity — so replay is safe and the existing checkpointer / thread-lock
+semantics are reused unchanged.
+
+Requires the optional ``durable`` extra:
+    pip install azure-functions-langgraph[durable]
+
+Run from this directory:
+    func start
+"""
+
+from __future__ import annotations
+
+from graph import compiled_graph
+
+from azure_functions_langgraph import LangGraphApp
+
+langgraph_app = LangGraphApp(async_runs="durable")
+
+langgraph_app.register(graph=compiled_graph, name="durable_async_agent")
+
+app = langgraph_app.function_app

--- a/examples/durable_async_agent/graph.py
+++ b/examples/durable_async_agent/graph.py
@@ -1,0 +1,42 @@
+"""Compiled graph for the durable async-agent example.
+
+A deterministic two-node graph with a small, artificial "slow" step so the
+durable async run lifecycle (create → poll pending/running → result) is
+observable end to end without any LLM or external dependency. No clock or
+randomness lives in the graph beyond a fixed sleep, and the whole thing runs in
+the Durable *activity*, never the orchestrator.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+
+
+def _slow_work(state: AgentState) -> dict[str, Any]:
+    # A tiny, deterministic delay standing in for real work (LLM/tool calls).
+    time.sleep(0.1)
+    return state
+
+
+def _respond(state: AgentState) -> dict[str, Any]:
+    user_msg = state["messages"][-1]["content"]
+    reply = {"role": "assistant", "content": f"Processed: {user_msg}"}
+    return {"messages": state["messages"] + [reply]}
+
+
+builder = StateGraph(AgentState)
+builder.add_node("work", _slow_work)
+builder.add_node("respond", _respond)
+builder.add_edge(START, "work")
+builder.add_edge("work", "respond")
+builder.add_edge("respond", END)
+
+compiled_graph = builder.compile()

--- a/examples/durable_async_agent/host.json
+++ b/examples/durable_async_agent/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/examples/durable_async_agent/local.settings.json.example
+++ b/examples/durable_async_agent/local.settings.json.example
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}

--- a/examples/durable_async_agent/requirements.txt
+++ b/examples/durable_async_agent/requirements.txt
@@ -1,0 +1,8 @@
+# Do not include azure-functions-worker in this file
+# The Python Worker is managed by the Azure Functions platform
+
+azure-functions
+azure-functions-durable>=1.2,<2.0
+azure-functions-langgraph[durable]>=0.8,<0.9
+langgraph>=1.1,<2.0
+langchain-core>=1.0,<2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ otel = [
 streaming = [
     "azurefunctions-extensions-http-fastapi>=1.0,<2",
 ]
+durable = [
+    "azure-functions-durable>=1.2,<2",
+]
 dev = [
     "bandit==1.9.4",
     "build",
@@ -95,6 +98,9 @@ dev = [
     # True HTTP streaming transport (StreamingLangGraphApp) — the streaming extra,
     # installed here so CI covers the ASGI/FastAPI extension import path.
     "azurefunctions-extensions-http-fastapi>=1.0,<2",
+    # Durable Functions async-run control plane (durable extra) — installed here
+    # so CI exercises the DFApp/orchestrator/activity import + wiring path.
+    "azure-functions-durable>=1.2,<2",
 ]
 docs = [
     "mkdocs<2.0",

--- a/src/azure_functions_langgraph/app.py
+++ b/src/azure_functions_langgraph/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import os
 from types import MappingProxyType
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Literal, Optional
 import warnings
 
 import azure.functions as func
@@ -56,6 +56,11 @@ _ROUTE_HEALTH_DETAILS = "health/details"
 _ROUTE_INVOKE = "graphs/{name}/invoke"
 _ROUTE_STREAM = "graphs/{name}/stream"
 _ROUTE_STATE = "graphs/{name}/threads/{{thread_id}}/state"
+
+# Async-run mode selector. ``False`` (default) serves only the synchronous HTTP
+# surface; ``"durable"`` additionally wires the optional Durable Functions
+# create/get/cancel async-run lifecycle (requires the ``durable`` extra, #408).
+AsyncRunsMode = Literal[False, "durable"]
 
 
 # Environment markers set by the Azure Functions host at runtime. Their presence
@@ -224,6 +229,7 @@ class LangGraphApp:
     max_input_depth: int = 32
     max_input_nodes: int = 10_000
     platform_compat: bool = False
+    async_runs: AsyncRunsMode = False
     thread_lock: Optional[ThreadLock] = None
     observer: Optional[RunObserver] = None
     route_prefix: str = _ROUTE_PREFIX  # metadata-only; must match host.json routePrefix
@@ -533,7 +539,7 @@ response_model: Optional Pydantic model class for response body
     # ------------------------------------------------------------------
 
     def _build_function_app(self) -> func.FunctionApp:
-        app = func.FunctionApp(http_auth_level=self.auth_level)
+        app = self._new_function_app()
 
         # Health endpoints.
         #
@@ -633,7 +639,46 @@ response_model: Optional Pydantic model class for response body
             )
             register_platform_routes(app, deps)
 
+        # Durable async-run control plane (issue #408)
+        if self.async_runs == "durable":
+            self._register_durable_runtime(app)
+
         return app
+
+    def _new_function_app(self) -> func.FunctionApp:
+        """Construct the underlying Functions app.
+
+        Returns a plain ``func.FunctionApp`` normally, or a Durable-aware
+        ``df.DFApp`` (typed as ``func.FunctionApp``) when ``async_runs="durable"``
+        so the same route registrations apply and the durable bindings are also
+        available. Building the DFApp requires the optional ``durable`` extra.
+        """
+        if self.async_runs == "durable":
+            from azure_functions_langgraph.durable._runtime import (
+                create_durable_function_app,
+            )
+
+            return create_durable_function_app(self.auth_level)
+        return func.FunctionApp(http_auth_level=self.auth_level)
+
+    def _register_durable_runtime(self, app: func.FunctionApp) -> None:
+        """Wire the Durable async-run orchestrator, activity, and HTTP routes."""
+        from azure_functions_langgraph.durable._runtime import (
+            DurableRuntimeDeps,
+            register_durable_runtime,
+        )
+
+        thread_lock = self.thread_lock
+        if thread_lock is None:  # pragma: no cover - invariant set in __post_init__
+            raise RuntimeError("thread_lock is None; __post_init__ did not run")
+
+        deps = DurableRuntimeDeps(
+            registry=self._registrations,
+            thread_lock=thread_lock,
+            observer=self.observer or NoOpRunObserver(),
+            max_request_body_bytes=self.max_request_body_bytes,
+        )
+        register_durable_runtime(app, deps)
 
     def _register_service_bus_trigger(
         self,

--- a/src/azure_functions_langgraph/durable/__init__.py
+++ b/src/azure_functions_langgraph/durable/__init__.py
@@ -1,0 +1,75 @@
+"""Optional Durable Functions-backed async-run control plane (issue #408).
+
+This subpackage adds an optional create/get/cancel async-run lifecycle on top of
+a :class:`~azure_functions_langgraph.app.LangGraphApp`, backed by Azure Durable
+Functions. It is gated behind the ``durable`` extra::
+
+    pip install azure-functions-langgraph[durable]
+
+Design boundaries (see issue #408):
+
+* The Durable **orchestrator** is trivial and deterministic — no I/O, clock,
+  randomness, LLM, tool, or graph user code.
+* All graph execution runs in a Durable **activity**, preserving replay
+  determinism and reusing the existing checkpointer / thread-lock semantics.
+* ``run_id == Durable instance_id == platform run_id`` — one stable id, no
+  second run registry.
+
+Durable history is **not** a replacement for LangGraph checkpoints, and this is
+not an "unlimited"-duration guarantee — it is an async run lifecycle over the
+existing graph runtime.
+
+Only :mod:`._runtime` imports ``azure.durable_functions``; the state, activity,
+orchestrator, and lifecycle modules are import-safe without the extra so they
+stay fully unit-testable.
+"""
+
+from __future__ import annotations
+
+from azure_functions_langgraph.durable._activity import (
+    GraphRegistrationLike,
+    execute_langgraph_run_impl,
+)
+from azure_functions_langgraph.durable._lifecycle import (
+    DurableClientLike,
+    OrchestrationStatusLike,
+    cancel_run_impl,
+    create_run_impl,
+    get_run_impl,
+    runtime_status_str,
+)
+from azure_functions_langgraph.durable._orchestrator import (
+    ACTIVITY_NAME,
+    OrchestrationContextLike,
+    run_orchestration,
+)
+from azure_functions_langgraph.durable._state import (
+    DurableRunPayload,
+    DurableRunResult,
+    DurableRunStatus,
+    normalize_status,
+    serialize_error,
+)
+
+__all__ = [
+    # State
+    "DurableRunStatus",
+    "DurableRunPayload",
+    "DurableRunResult",
+    "normalize_status",
+    "serialize_error",
+    # Activity
+    "GraphRegistrationLike",
+    "execute_langgraph_run_impl",
+    # Orchestrator
+    "ACTIVITY_NAME",
+    "OrchestrationContextLike",
+    "run_orchestration",
+    # Lifecycle
+    "DurableClientLike",
+    "OrchestrationStatusLike",
+    "create_run_impl",
+    "get_run_impl",
+    "cancel_run_impl",
+    "runtime_status_str",
+]

--- a/src/azure_functions_langgraph/durable/_activity.py
+++ b/src/azure_functions_langgraph/durable/_activity.py
@@ -1,0 +1,132 @@
+"""The Durable *activity* that actually executes a LangGraph run.
+
+All user/graph code, network, LLM, tool, clock and randomness lives here — in a
+Durable **activity**, never in the orchestrator — so the orchestrator stays
+deterministic and replay-safe (issue #408).
+
+The activity mirrors the Service Bus trigger's execution shape
+(:mod:`azure_functions_langgraph.triggers.service_bus`): resolve the registered
+graph, acquire the existing per-thread lock when the graph is checkpointed and a
+``thread_id`` is present, invoke the graph, and emit the ``RunObserver``
+lifecycle. The crucial difference is that the activity **never re-raises** —
+graph failures and lock contention are captured into a normalized
+:class:`~azure_functions_langgraph.durable._state.DurableRunResult` so the
+orchestration *completes* with a normalized output rather than surfacing as a
+Durable ``Failed`` status (which would also trigger Durable's at-least-once
+activity retry). This keeps a single logical run record per ``run_id``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
+
+from azure_functions_langgraph.durable._state import DurableRunPayload, DurableRunResult
+from azure_functions_langgraph.locks import ThreadLock
+from azure_functions_langgraph.observability import (
+    NOOP_OBSERVER,
+    RunObserver,
+    finish_context,
+    new_run_context,
+    safe_observer_call,
+)
+
+__all__ = ["GraphRegistrationLike", "execute_langgraph_run_impl"]
+
+# The generic trigger label stamped onto every RunContext this adapter emits so
+# exporters can distinguish durable async runs from HTTP invoke/stream runs.
+TRIGGER_TYPE = "durable"
+
+
+@runtime_checkable
+class GraphRegistrationLike(Protocol):
+    """Structural subset of the app's internal graph registration record.
+
+    Declares only the members the activity reads, so tests can supply a
+    lightweight fake and the activity never has to import
+    :class:`azure_functions_langgraph.app._GraphRegistration` (avoiding a cycle).
+    """
+
+    graph: Any
+    name: str
+    async_mode: bool
+
+
+def _has_checkpointer(graph: Any) -> bool:
+    """Whether a compiled graph has a checkpointer attached."""
+
+    return getattr(graph, "checkpointer", None) is not None
+
+
+async def execute_langgraph_run_impl(
+    payload: DurableRunPayload,
+    *,
+    registry: Mapping[str, GraphRegistrationLike],
+    thread_lock: ThreadLock,
+    observer: RunObserver = NOOP_OBSERVER,
+) -> DurableRunResult:
+    """Execute one graph run for a durable async orchestration.
+
+    Returns a normalized :class:`DurableRunResult` (never raises for graph or
+    lock-contention failures), so the calling orchestration completes with a
+    deterministic, JSON-serializable output.
+    """
+
+    reg = registry.get(payload.graph_name)
+    if reg is None:
+        return DurableRunResult.failure(
+            payload.run_id,
+            KeyError(f"No graph registered under name {payload.graph_name!r}"),
+        )
+
+    thread_id = payload.thread_id
+    has_ckpt = _has_checkpointer(reg.graph)
+    ctx = new_run_context(
+        reg.name,
+        "invoke",
+        run_id=payload.run_id,
+        thread_id=thread_id,
+        assistant_id=payload.assistant_id,
+        has_checkpointer=has_ckpt,
+        lock_backend=type(thread_lock).__name__,
+        trigger_type=TRIGGER_TYPE,
+    )
+
+    lock_token: Optional[str] = None
+    use_lock = bool(thread_id) and has_ckpt
+    if use_lock and thread_id is not None:
+        lock_token = await asyncio.to_thread(thread_lock.acquire, reg.name, thread_id)
+        if not lock_token:
+            safe_observer_call(observer, "on_run_rejected", finish_context(ctx), "lock_contention")
+            return DurableRunResult.rejected(
+                payload.run_id,
+                f"Thread {thread_id!r} for graph {reg.name!r} is currently in use",
+            )
+
+    config = payload.config or ({"configurable": {"thread_id": thread_id}} if thread_id else None)
+    safe_observer_call(observer, "on_run_started", ctx)
+    try:
+        result = await _invoke_graph(reg, payload.input, config)
+    except BaseException as exc:  # noqa: BLE001 - captured into a normalized result
+        safe_observer_call(observer, "on_run_failed", finish_context(ctx), exc)
+        return DurableRunResult.failure(payload.run_id, exc)
+    else:
+        safe_observer_call(observer, "on_run_completed", finish_context(ctx))
+        return DurableRunResult.success(payload.run_id, result)
+    finally:
+        if lock_token is not None and thread_id is not None:
+            await asyncio.to_thread(thread_lock.release, reg.name, thread_id, lock_token)
+
+
+async def _invoke_graph(
+    reg: GraphRegistrationLike, graph_input: Any, config: Optional[dict[str, Any]]
+) -> Any:
+    """Invoke the graph, using ``ainvoke`` when the registration is async."""
+
+    if reg.async_mode:
+        if config is not None:
+            return await reg.graph.ainvoke(graph_input, config=config)
+        return await reg.graph.ainvoke(graph_input)
+    if config is not None:
+        return await asyncio.to_thread(reg.graph.invoke, graph_input, config=config)
+    return await asyncio.to_thread(reg.graph.invoke, graph_input)

--- a/src/azure_functions_langgraph/durable/_lifecycle.py
+++ b/src/azure_functions_langgraph/durable/_lifecycle.py
@@ -1,0 +1,165 @@
+"""HTTP control-plane handlers for the Durable async-run lifecycle.
+
+Implements ``runs.create`` / ``runs.get`` / ``runs.cancel`` as pure async
+functions that take already-parsed inputs and a
+:class:`DurableClientLike` client, returning ``(status_code, body)`` tuples.
+Keeping the handlers free of ``azure.functions`` request/response types (and of
+any ``azure.durable_functions`` import) makes the entire lifecycle unit-testable
+with a fake client and no Azure host (issue #408). The thin decorated HTTP
+functions in :mod:`azure_functions_langgraph.durable._runtime` adapt
+``func.HttpRequest`` to these impls and build ``func.HttpResponse``.
+
+Identifier model (per the design review): ``run_id == Durable instance_id ==
+platform run_id`` — one stable id, no second run registry. Durable instance
+state is the single source of truth for lifecycle status.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
+from uuid import uuid4
+
+from azure_functions_langgraph.durable._orchestrator import ACTIVITY_NAME  # noqa: F401
+from azure_functions_langgraph.durable._state import (
+    DurableRunPayload,
+    DurableRunStatus,
+    normalize_status,
+)
+
+__all__ = [
+    "DurableClientLike",
+    "OrchestrationStatusLike",
+    "create_run_impl",
+    "get_run_impl",
+    "cancel_run_impl",
+    "runtime_status_str",
+]
+
+
+@runtime_checkable
+class OrchestrationStatusLike(Protocol):
+    """Structural subset of ``DurableOrchestrationStatus`` read by the handlers."""
+
+    runtime_status: Any
+    output: Any
+
+
+@runtime_checkable
+class DurableClientLike(Protocol):
+    """Structural subset of ``DurableOrchestrationClient`` used by the control plane.
+
+    Declared so lifecycle handlers can be tested with a fake client and never
+    need a real Durable Task backend. Method shapes mirror the async SDK surface.
+    """
+
+    async def start_new(
+        self,
+        orchestration_function_name: str,
+        instance_id: Optional[str] = None,
+        client_input: Any = None,
+    ) -> str:
+        """Start a new orchestration; returns the instance id."""
+        ...
+
+    async def get_status(self, instance_id: str) -> Optional[OrchestrationStatusLike]:
+        """Return the orchestration status, or a not-found sentinel."""
+        ...
+
+    async def terminate(self, instance_id: str, reason: str) -> None:
+        """Terminate a running orchestration."""
+        ...
+
+
+def runtime_status_str(status: Optional[OrchestrationStatusLike]) -> Optional[str]:
+    """Extract a plain runtime-status string from a status object.
+
+    Tolerates both a string ``runtime_status`` and an
+    ``OrchestrationRuntimeStatus`` enum (using its ``.name``), returning ``None``
+    when the status object is missing or carries no runtime status (not found).
+    """
+
+    if status is None:
+        return None
+    raw = getattr(status, "runtime_status", None)
+    if raw is None:
+        return None
+    # Enum → its member name (e.g. OrchestrationRuntimeStatus.Running -> "Running");
+    # plain strings pass through unchanged.
+    name = getattr(raw, "name", None)
+    return name if isinstance(name, str) else str(raw)
+
+
+async def create_run_impl(
+    client: DurableClientLike,
+    orchestrator_name: str,
+    body: Mapping[str, Any],
+    *,
+    graph_name: str,
+) -> tuple[int, dict[str, Any]]:
+    """Start a durable async run and return ``(202, {run_id, status})``.
+
+    ``body`` is the parsed request payload: ``input`` (required-ish, defaulted to
+    ``None``), optional ``config``, ``thread_id``, ``assistant_id``, and an
+    optional client-supplied ``run_id`` (idempotency key). When ``run_id`` is
+    omitted a fresh one is minted here (HTTP side — non-determinism is fine).
+    """
+
+    run_id = str(body.get("run_id") or uuid4().hex)
+    config = dict(body.get("config") or {})
+    thread_id = body.get("thread_id")
+    # Derive thread_id from config.configurable when not explicit.
+    if thread_id is None:
+        configurable = config.get("configurable") if isinstance(config, dict) else None
+        if isinstance(configurable, Mapping):
+            thread_id = configurable.get("thread_id")
+
+    payload = DurableRunPayload(
+        run_id=run_id,
+        graph_name=graph_name,
+        input=body.get("input"),
+        thread_id=thread_id,
+        config=config,
+        assistant_id=body.get("assistant_id"),
+        correlation_id=body.get("correlation_id"),
+    )
+
+    await client.start_new(orchestrator_name, instance_id=run_id, client_input=payload.to_dict())
+    return 202, {"run_id": run_id, "status": "pending"}
+
+
+async def get_run_impl(client: DurableClientLike, run_id: str) -> tuple[int, dict[str, Any]]:
+    """Poll a durable run's normalized status.
+
+    Returns ``(404, {...})`` when the instance is unknown, otherwise ``(200,
+    {run_id, status, output})`` where ``status`` is the normalized lifecycle
+    status and ``output`` is the orchestration output (present once completed).
+    """
+
+    status = await client.get_status(run_id)
+    runtime = runtime_status_str(status)
+    if runtime is None:
+        return 404, {"run_id": run_id, "error": "run not found"}
+
+    output = getattr(status, "output", None)
+    output_mapping = output if isinstance(output, Mapping) else None
+    normalized: DurableRunStatus = normalize_status(runtime, output_mapping)
+    return 200, {"run_id": run_id, "status": normalized, "output": output}
+
+
+async def cancel_run_impl(
+    client: DurableClientLike, run_id: str, *, reason: str = "cancelled by client"
+) -> tuple[int, dict[str, Any]]:
+    """Cancel a durable run by terminating its orchestration.
+
+    Returns ``(404, {...})`` when the instance is unknown, otherwise ``(202,
+    {run_id, status: "cancelled"})``. Terminate is best-effort and asynchronous
+    on the Durable side; the normalized status becomes ``cancelled`` once the
+    termination is applied.
+    """
+
+    status = await client.get_status(run_id)
+    if runtime_status_str(status) is None:
+        return 404, {"run_id": run_id, "error": "run not found"}
+
+    await client.terminate(run_id, reason)
+    return 202, {"run_id": run_id, "status": "cancelled"}

--- a/src/azure_functions_langgraph/durable/_orchestrator.py
+++ b/src/azure_functions_langgraph/durable/_orchestrator.py
@@ -1,0 +1,59 @@
+"""The deterministic Durable *orchestrator* for async runs.
+
+The orchestrator is intentionally trivial and **must remain deterministic**: it
+reads the orchestration input, calls the single ``execute_langgraph_run``
+activity, and returns its normalized result. It performs no I/O, no clock or
+random access, no logging side effects, no observer calls, and no graph
+execution — all of that lives in the activity — so Durable replay is safe
+(issue #408).
+
+The orchestration logic is factored into :func:`run_orchestration`, a plain
+generator that depends only on a small :class:`OrchestrationContextLike`
+protocol, so it can be unit-tested by driving the generator with a fake context
+(no Azure host, no ``azure.durable_functions`` import required).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Generator, Protocol, runtime_checkable
+
+__all__ = [
+    "ACTIVITY_NAME",
+    "OrchestrationContextLike",
+    "run_orchestration",
+]
+
+# Stable Durable activity function name; also referenced by the runtime wiring.
+ACTIVITY_NAME = "execute_langgraph_run"
+
+
+@runtime_checkable
+class OrchestrationContextLike(Protocol):
+    """Structural subset of ``DurableOrchestrationContext`` used here.
+
+    Only the two members the orchestrator touches are declared, so the
+    deterministic logic can be exercised with a fake context in unit tests.
+    """
+
+    def get_input(self) -> Any:
+        """Return the client input the orchestration was started with."""
+        ...
+
+    def call_activity(self, name: str, input_: Any) -> Any:
+        """Schedule an activity call and return a Durable ``Task`` to yield."""
+        ...
+
+
+def run_orchestration(
+    context: OrchestrationContextLike,
+) -> Generator[Any, Any, Any]:
+    """Deterministically call the run activity and return its result.
+
+    Yields exactly one activity task (``execute_langgraph_run``) with the
+    orchestration input passed through verbatim, then returns the activity's
+    normalized result dict as the orchestration output.
+    """
+
+    payload = context.get_input()
+    result = yield context.call_activity(ACTIVITY_NAME, payload)
+    return result

--- a/src/azure_functions_langgraph/durable/_runtime.py
+++ b/src/azure_functions_langgraph/durable/_runtime.py
@@ -162,9 +162,8 @@ async def create_run_http(
         return _json_response(404, {"error": f"no graph registered under name {graph_name!r}"})
 
     body, error = _parse_body(req, max_bytes=max_request_body_bytes)
-    if error is not None:
-        return _json_response(400, {"error": error})
-    assert body is not None  # for type-checkers; error is None here
+    if error is not None or body is None:
+        return _json_response(400, {"error": error or "invalid request body"})
 
     status_code, result = await create_run_impl(
         client, orchestrator_name, body, graph_name=graph_name

--- a/src/azure_functions_langgraph/durable/_runtime.py
+++ b/src/azure_functions_langgraph/durable/_runtime.py
@@ -1,0 +1,246 @@
+"""Durable Functions runtime wiring for the async-run control plane.
+
+This is the only module in the ``durable`` package that touches the
+``azure.durable_functions`` SDK, so it is imported lazily (behind the optional
+``durable`` extra). It:
+
+* constructs a ``df.DFApp`` (an :class:`azure.functions.FunctionApp`-compatible
+  app that also understands orchestration/activity/durable-client bindings),
+* registers the deterministic orchestrator
+  (:func:`~azure_functions_langgraph.durable._orchestrator.run_orchestration`)
+  and the run activity
+  (:func:`~azure_functions_langgraph.durable._activity.execute_langgraph_run_impl`),
+  and
+* registers the three lifecycle HTTP routes (create / get / cancel) that adapt
+  ``func.HttpRequest`` to the pure handlers in
+  :mod:`azure_functions_langgraph.durable._lifecycle`.
+
+The pure request→response adapters (:func:`create_run_http`,
+:func:`get_run_http`, :func:`cancel_run_http`) are module-level and take an
+already-constructed :class:`DurableClientLike`, so the whole HTTP surface is
+unit-testable with a fake client and no Durable Task backend. Only the thin
+decorator registration in :func:`register_durable_runtime` needs the real SDK.
+
+Identifier model (issue #408): ``run_id == Durable instance_id == platform
+run_id`` — one stable id, no second registry; Durable instance state is the
+single source of truth for lifecycle status.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping
+
+import azure.functions as func
+
+from azure_functions_langgraph.durable._activity import (
+    GraphRegistrationLike,
+    execute_langgraph_run_impl,
+)
+from azure_functions_langgraph.durable._lifecycle import (
+    DurableClientLike,
+    cancel_run_impl,
+    create_run_impl,
+    get_run_impl,
+)
+from azure_functions_langgraph.durable._orchestrator import run_orchestration
+from azure_functions_langgraph.durable._state import DurableRunPayload, DurableRunResult
+from azure_functions_langgraph.locks import ThreadLock
+from azure_functions_langgraph.observability import NOOP_OBSERVER, RunObserver
+
+__all__ = [
+    "ORCHESTRATOR_NAME",
+    "DurableRuntimeDeps",
+    "create_durable_function_app",
+    "register_durable_runtime",
+    "create_run_http",
+    "get_run_http",
+    "cancel_run_http",
+]
+
+# Friendly install hint surfaced when the optional ``durable`` extra is missing.
+_EXTRA_HINT = (
+    "Durable async runs require the optional 'durable' extra. "
+    "Install it with: pip install azure-functions-langgraph[durable]"
+)
+
+# Stable Durable orchestrator function name. Referenced by ``create_run_impl``
+# when starting a new orchestration; must match the registered orchestrator.
+ORCHESTRATOR_NAME = "langgraph_durable_run_orchestrator"
+
+# Lifecycle HTTP route templates (relative to the host ``routePrefix``).
+_ROUTE_CREATE_RUN = "graphs/{name}/runs"
+_ROUTE_GET_RUN = "runs/{run_id}"
+_ROUTE_CANCEL_RUN = "runs/{run_id}/cancel"
+
+
+def _import_durable() -> Any:
+    """Import ``azure.durable_functions`` or raise a friendly ImportError."""
+
+    try:
+        import azure.durable_functions as df
+    except ImportError as exc:  # pragma: no cover - exercised via the extra guard
+        raise ImportError(_EXTRA_HINT) from exc
+    return df
+
+
+@dataclass(frozen=True)
+class DurableRuntimeDeps:
+    """Everything the durable runtime needs from the owning ``LangGraphApp``.
+
+    Declared with structural types so the runtime never imports the app's
+    concrete registration record (avoiding an import cycle).
+    """
+
+    registry: Mapping[str, GraphRegistrationLike]
+    thread_lock: ThreadLock
+    observer: RunObserver = NOOP_OBSERVER
+    max_request_body_bytes: int = 1024 * 1024
+
+
+def create_durable_function_app(auth_level: func.AuthLevel) -> func.FunctionApp:
+    """Construct a ``df.DFApp`` typed as a ``func.FunctionApp`` for the caller.
+
+    ``DFApp`` is not literally a ``func.FunctionApp`` subclass, but it inherits
+    the same trigger/binding/registration surface (``.route``,
+    ``.function_name``, ``.service_bus_*_trigger``) *plus* the durable bindings,
+    and the worker indexes it identically. The return is annotated as
+    ``func.FunctionApp`` so the rest of the app treats it uniformly.
+    """
+
+    df = _import_durable()
+    app = df.DFApp(http_auth_level=auth_level)
+    return app  # type: ignore[no-any-return]
+
+
+def _json_response(status_code: int, body: Mapping[str, Any]) -> func.HttpResponse:
+    """Build a JSON ``func.HttpResponse`` for a lifecycle result."""
+
+    return func.HttpResponse(
+        body=json.dumps(body),
+        mimetype="application/json",
+        status_code=status_code,
+    )
+
+
+def _parse_body(
+    req: func.HttpRequest, *, max_bytes: int
+) -> tuple[Mapping[str, Any] | None, str | None]:
+    """Parse a JSON object request body, returning ``(body, error)``.
+
+    An empty body is treated as ``{}``. A body larger than ``max_bytes``, or one
+    that is not a JSON object, yields an error string (and a ``None`` body).
+    """
+
+    raw = req.get_body() or b""
+    if len(raw) > max_bytes:
+        return None, f"request body exceeds {max_bytes} bytes"
+    if not raw:
+        return {}, None
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return None, "request body is not valid JSON"
+    if not isinstance(parsed, Mapping):
+        return None, "request body must be a JSON object"
+    return parsed, None
+
+
+async def create_run_http(
+    client: DurableClientLike,
+    req: func.HttpRequest,
+    *,
+    registry: Mapping[str, GraphRegistrationLike],
+    orchestrator_name: str = ORCHESTRATOR_NAME,
+    max_request_body_bytes: int = 1024 * 1024,
+) -> func.HttpResponse:
+    """Adapt ``POST graphs/{name}/runs`` to :func:`create_run_impl`."""
+
+    graph_name = req.route_params.get("name", "")
+    if graph_name not in registry:
+        return _json_response(404, {"error": f"no graph registered under name {graph_name!r}"})
+
+    body, error = _parse_body(req, max_bytes=max_request_body_bytes)
+    if error is not None:
+        return _json_response(400, {"error": error})
+    assert body is not None  # for type-checkers; error is None here
+
+    status_code, result = await create_run_impl(
+        client, orchestrator_name, body, graph_name=graph_name
+    )
+    return _json_response(status_code, result)
+
+
+async def get_run_http(client: DurableClientLike, req: func.HttpRequest) -> func.HttpResponse:
+    """Adapt ``GET runs/{run_id}`` to :func:`get_run_impl`."""
+
+    run_id = req.route_params.get("run_id", "")
+    status_code, result = await get_run_impl(client, run_id)
+    return _json_response(status_code, result)
+
+
+async def cancel_run_http(client: DurableClientLike, req: func.HttpRequest) -> func.HttpResponse:
+    """Adapt ``POST runs/{run_id}/cancel`` to :func:`cancel_run_impl`."""
+
+    run_id = req.route_params.get("run_id", "")
+    status_code, result = await cancel_run_impl(client, run_id)
+    return _json_response(status_code, result)
+
+
+def register_durable_runtime(app: func.FunctionApp, deps: DurableRuntimeDeps) -> None:
+    """Register the orchestrator, activity, and lifecycle routes on ``app``.
+
+    ``app`` must be a ``df.DFApp`` (as returned by
+    :func:`create_durable_function_app`). The graph registry, thread lock, and
+    observer are captured in closures so the activity resolves and runs graphs
+    exactly like the Service Bus trigger, while the orchestrator stays a pure
+    deterministic generator.
+    """
+
+    registry = deps.registry
+    thread_lock = deps.thread_lock
+    observer = deps.observer
+    max_body = deps.max_request_body_bytes
+
+    # --- Deterministic orchestrator -------------------------------------
+    @app.orchestration_trigger(context_name="context")  # type: ignore[untyped-decorator]
+    def langgraph_durable_run_orchestrator(context: Any) -> Any:
+        return run_orchestration(context)
+
+    # --- Run activity (all user/graph code lives here) ------------------
+    @app.activity_trigger(input_name="payload")  # type: ignore[untyped-decorator]
+    async def execute_langgraph_run(payload: Any) -> dict[str, Any]:
+        parsed = DurableRunPayload.from_dict(payload)
+        result: DurableRunResult = await execute_langgraph_run_impl(
+            parsed,
+            registry=registry,
+            thread_lock=thread_lock,
+            observer=observer,
+        )
+        return result.to_dict()
+
+    # --- Lifecycle HTTP routes ------------------------------------------
+    @app.function_name(name="aflg_durable_create_run")
+    @app.route(route=_ROUTE_CREATE_RUN, methods=["POST"])
+    @app.durable_client_input(client_name="client")  # type: ignore[untyped-decorator]
+    async def create_run(req: func.HttpRequest, client: DurableClientLike) -> func.HttpResponse:
+        return await create_run_http(
+            client,
+            req,
+            registry=registry,
+            orchestrator_name=ORCHESTRATOR_NAME,
+            max_request_body_bytes=max_body,
+        )
+
+    @app.function_name(name="aflg_durable_get_run")
+    @app.route(route=_ROUTE_GET_RUN, methods=["GET"])
+    @app.durable_client_input(client_name="client")  # type: ignore[untyped-decorator]
+    async def get_run(req: func.HttpRequest, client: DurableClientLike) -> func.HttpResponse:
+        return await get_run_http(client, req)
+
+    @app.function_name(name="aflg_durable_cancel_run")
+    @app.route(route=_ROUTE_CANCEL_RUN, methods=["POST"])
+    @app.durable_client_input(client_name="client")  # type: ignore[untyped-decorator]
+    async def cancel_run(req: func.HttpRequest, client: DurableClientLike) -> func.HttpResponse:
+        return await cancel_run_http(client, req)

--- a/src/azure_functions_langgraph/durable/_state.py
+++ b/src/azure_functions_langgraph/durable/_state.py
@@ -1,0 +1,191 @@
+"""Pure state models and status mapping for the Durable async-run control plane.
+
+This module is intentionally free of any ``azure.durable_functions`` import so it
+stays importable without the ``durable`` extra and is fully unit-testable without
+Azure. It defines:
+
+* :data:`DurableRunStatus` — the normalized, transport-agnostic run status.
+* :func:`normalize_status` — maps a Durable ``runtime_status`` (plus the
+  orchestration output) onto :data:`DurableRunStatus`.
+* :class:`DurableRunPayload` / :class:`DurableRunResult` — the JSON-serializable
+  activity input/output records passed through Durable orchestration history.
+* :func:`serialize_error` — a safe, JSON-serializable error shape (type + message
+  only; never a traceback or arbitrary object).
+
+The orchestrator MUST stay deterministic, so everything here is pure: no clocks,
+no randomness, no I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping, Optional, cast
+
+__all__ = [
+    "DurableRunStatus",
+    "DurableRunPayload",
+    "DurableRunResult",
+    "normalize_status",
+    "serialize_error",
+]
+
+# Normalized lifecycle status exposed by the durable async-run endpoints.
+# ``rejected`` is folded into ``error`` at the HTTP boundary to match the
+# existing platform ``RunStatus`` vocabulary, but the activity output can carry
+# an ``activity_status`` of ``"rejected"`` for observability.
+DurableRunStatus = Literal["pending", "running", "success", "error", "cancelled"]
+
+# Activity-level outcome recorded in the orchestration output payload.
+_ActivityStatus = Literal["success", "error", "rejected"]
+
+
+def serialize_error(exc: BaseException) -> dict[str, str]:
+    """Return a safe, JSON-serializable error shape (type + message only).
+
+    Never includes a traceback, ``args`` beyond the string form, or any
+    arbitrary object — consistent with the observability boundary that a run's
+    correlation surface carries the exception *type* and message only.
+    """
+
+    return {"type": type(exc).__name__, "message": str(exc)}
+
+
+@dataclass(frozen=True)
+class DurableRunPayload:
+    """JSON-serializable input handed to the ``execute_langgraph_run`` activity.
+
+    Carries the stable ``run_id`` (== Durable ``instance_id`` == platform run id)
+    so replay never mints a second logical run, plus the graph selector and the
+    LangGraph invoke ``input`` / ``config``.
+    """
+
+    run_id: str
+    graph_name: str
+    input: Any
+    thread_id: Optional[str] = None
+    config: dict[str, Any] = field(default_factory=dict)
+    assistant_id: Optional[str] = None
+    correlation_id: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain ``dict`` for Durable orchestration input."""
+
+        return {
+            "run_id": self.run_id,
+            "graph_name": self.graph_name,
+            "input": self.input,
+            "thread_id": self.thread_id,
+            "config": self.config,
+            "assistant_id": self.assistant_id,
+            "correlation_id": self.correlation_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> DurableRunPayload:
+        """Rehydrate from the dict Durable passes to the activity."""
+
+        return cls(
+            run_id=str(data["run_id"]),
+            graph_name=str(data["graph_name"]),
+            input=data.get("input"),
+            thread_id=data.get("thread_id"),
+            config=dict(data.get("config") or {}),
+            assistant_id=data.get("assistant_id"),
+            correlation_id=data.get("correlation_id"),
+        )
+
+
+@dataclass(frozen=True)
+class DurableRunResult:
+    """JSON-serializable activity output; becomes the orchestration output.
+
+    ``activity_status`` records the activity-level outcome; ``result`` holds the
+    graph output on success, and ``error`` holds a :func:`serialize_error` shape
+    on failure/rejection.
+    """
+
+    run_id: str
+    activity_status: _ActivityStatus
+    result: Any = None
+    error: Optional[dict[str, str]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain ``dict`` for the orchestration output."""
+
+        return {
+            "run_id": self.run_id,
+            "activity_status": self.activity_status,
+            "result": self.result,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> DurableRunResult:
+        """Rehydrate from a serialized orchestration output ``dict``."""
+
+        return cls(
+            run_id=str(data["run_id"]),
+            activity_status=cast(_ActivityStatus, data["activity_status"]),
+            result=data.get("result"),
+            error=data.get("error"),
+        )
+
+    @classmethod
+    def success(cls, run_id: str, result: Any) -> DurableRunResult:
+        """Build a successful result carrying the graph output."""
+
+        return cls(run_id=run_id, activity_status="success", result=result)
+
+    @classmethod
+    def failure(cls, run_id: str, exc: BaseException) -> DurableRunResult:
+        """Build a failed result from an exception."""
+
+        return cls(run_id=run_id, activity_status="error", error=serialize_error(exc))
+
+    @classmethod
+    def rejected(cls, run_id: str, reason: str) -> DurableRunResult:
+        """Build a rejected result (e.g. thread lock contention)."""
+
+        return cls(
+            run_id=run_id,
+            activity_status="rejected",
+            error={"type": "ThreadContentionError", "message": reason},
+        )
+
+
+def normalize_status(
+    runtime_status: Optional[str],
+    output: Optional[Mapping[str, Any]] = None,
+) -> DurableRunStatus:
+    """Map a Durable ``runtime_status`` (+ output) onto :data:`DurableRunStatus`.
+
+    ``output`` is the orchestration output — a serialized :class:`DurableRunResult`
+    — consulted only when the orchestration ``Completed`` so an activity-level
+    ``error`` / ``rejected`` surfaces as a normalized ``error`` even though the
+    orchestration itself completed successfully.
+
+    Unknown / ``None`` runtime statuses are treated as ``running`` (the run is
+    in-flight from the caller's perspective) rather than raising, so a transient
+    Durable query gap never crashes ``runs.get``.
+    """
+
+    status = (runtime_status or "").strip()
+
+    if status in ("", "Pending"):
+        return "pending" if status == "Pending" else "running"
+    if status == "Running":
+        return "running"
+    if status in ("Suspended", "ContinuedAsNew"):
+        return "running"
+    if status == "Completed":
+        activity_status = None
+        if output is not None:
+            activity_status = output.get("activity_status")
+        if activity_status in ("error", "rejected"):
+            return "error"
+        return "success"
+    if status == "Failed":
+        return "error"
+    if status in ("Terminated", "Canceled", "Cancelled"):
+        return "cancelled"
+    return "running"

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -1,0 +1,508 @@
+"""Deterministic tests for the Durable async-run control plane (issue #408).
+
+Covers the pure activity/orchestrator/lifecycle logic plus the runtime HTTP
+adapters and DFApp registration, all with in-process fakes — no Azure host and
+no Durable Task backend required.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import azure.functions as func
+import pytest
+
+from azure_functions_langgraph.app import LangGraphApp
+from azure_functions_langgraph.durable._activity import execute_langgraph_run_impl
+from azure_functions_langgraph.durable._lifecycle import (
+    cancel_run_impl,
+    create_run_impl,
+    get_run_impl,
+    runtime_status_str,
+)
+from azure_functions_langgraph.durable._orchestrator import (
+    ACTIVITY_NAME,
+    run_orchestration,
+)
+from azure_functions_langgraph.durable._runtime import (
+    ORCHESTRATOR_NAME,
+    DurableRuntimeDeps,
+    _parse_body,
+    cancel_run_http,
+    create_durable_function_app,
+    create_run_http,
+    get_run_http,
+    register_durable_runtime,
+)
+from azure_functions_langgraph.durable._state import (
+    DurableRunPayload,
+    normalize_status,
+)
+from azure_functions_langgraph.locks import InProcessThreadLock
+from azure_functions_langgraph.observability import RunContext
+
+
+# --------------------------------------------------------------------------
+# Fakes
+# --------------------------------------------------------------------------
+class FakeGraph:
+    def __init__(self, *, checkpointer: Any = None, result: Any = None, boom: bool = False) -> None:
+        self.checkpointer = checkpointer
+        self._result = result if result is not None else {"ok": True}
+        self._boom = boom
+        self.calls: list[tuple[Any, Any]] = []
+
+    def invoke(self, input: Any, config: Any = None) -> Any:
+        self.calls.append((input, config))
+        if self._boom:
+            raise RuntimeError("boom")
+        return self._result
+
+
+class FakeAsyncGraph:
+    def __init__(self, *, checkpointer: Any = None, result: Any = None) -> None:
+        self.checkpointer = checkpointer
+        self._result = result if result is not None else {"ok": True}
+        self.calls: list[tuple[Any, Any]] = []
+
+    async def ainvoke(self, input: Any, config: Any = None) -> Any:
+        self.calls.append((input, config))
+        return self._result
+
+
+class FakeReg:
+    def __init__(self, graph: Any, name: str, async_mode: bool = False) -> None:
+        self.graph = graph
+        self.name = name
+        self.async_mode = async_mode
+
+
+class RecordingObserver:
+    def __init__(self) -> None:
+        self.events: list[str] = []
+
+    def on_run_started(self, ctx: RunContext) -> None:
+        self.events.append("started")
+
+    def on_run_completed(self, ctx: RunContext) -> None:
+        self.events.append("completed")
+
+    def on_run_failed(self, ctx: RunContext, exc: BaseException) -> None:
+        self.events.append("failed")
+
+    def on_run_rejected(self, ctx: RunContext, reason: str) -> None:
+        self.events.append("rejected")
+
+
+class FakeStatus:
+    def __init__(self, runtime_status: Any, output: Any = None) -> None:
+        self.runtime_status = runtime_status
+        self.output = output
+
+
+class _Enum:
+    """Mimics an OrchestrationRuntimeStatus enum member (has ``.name``)."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class FakeDurableClient:
+    def __init__(self, status: Optional[FakeStatus] = None) -> None:
+        self._status = status
+        self.started: list[tuple[str, Optional[str], Any]] = []
+        self.terminated: list[tuple[str, str]] = []
+
+    async def start_new(
+        self,
+        orchestration_function_name: str,
+        instance_id: Optional[str] = None,
+        client_input: Any = None,
+    ) -> str:
+        self.started.append((orchestration_function_name, instance_id, client_input))
+        return instance_id or "generated-id"
+
+    async def get_status(self, instance_id: str) -> Optional[FakeStatus]:
+        return self._status
+
+    async def terminate(self, instance_id: str, reason: str) -> None:
+        self.terminated.append((instance_id, reason))
+
+
+def _payload(**kw: Any) -> DurableRunPayload:
+    base: dict[str, Any] = {"run_id": "r1", "graph_name": "echo", "input": {"x": 1}}
+    base.update(kw)
+    return DurableRunPayload(**base)
+
+
+# --------------------------------------------------------------------------
+# Activity
+# --------------------------------------------------------------------------
+class TestActivity:
+    async def test_success_sync_graph(self) -> None:
+        graph = FakeGraph(result={"done": True})
+        reg = FakeReg(graph, "echo")
+        obs = RecordingObserver()
+        result = await execute_langgraph_run_impl(
+            _payload(), registry={"echo": reg}, thread_lock=InProcessThreadLock(), observer=obs
+        )
+        assert result.activity_status == "success"
+        assert result.result == {"done": True}
+        assert obs.events == ["started", "completed"]
+
+    async def test_success_async_graph(self) -> None:
+        graph = FakeAsyncGraph(result={"a": 2})
+        reg = FakeReg(graph, "echo", async_mode=True)
+        result = await execute_langgraph_run_impl(
+            _payload(), registry={"echo": reg}, thread_lock=InProcessThreadLock()
+        )
+        assert result.activity_status == "success"
+        assert result.result == {"a": 2}
+
+    async def test_unknown_graph_returns_failure(self) -> None:
+        result = await execute_langgraph_run_impl(
+            _payload(graph_name="missing"),
+            registry={},
+            thread_lock=InProcessThreadLock(),
+        )
+        assert result.activity_status == "error"
+        assert result.error is not None
+        assert result.error["type"] == "KeyError"
+
+    async def test_graph_failure_captured(self) -> None:
+        graph = FakeGraph(boom=True)
+        reg = FakeReg(graph, "echo")
+        obs = RecordingObserver()
+        result = await execute_langgraph_run_impl(
+            _payload(), registry={"echo": reg}, thread_lock=InProcessThreadLock(), observer=obs
+        )
+        assert result.activity_status == "error"
+        assert result.error == {"type": "RuntimeError", "message": "boom"}
+        assert obs.events == ["started", "failed"]
+
+    async def test_lock_used_with_checkpointer_and_thread_id(self) -> None:
+        graph = FakeGraph(checkpointer=object(), result={"ok": 1})
+        reg = FakeReg(graph, "echo")
+        lock = InProcessThreadLock()
+        result = await execute_langgraph_run_impl(
+            _payload(thread_id="t1"), registry={"echo": reg}, thread_lock=lock
+        )
+        assert result.activity_status == "success"
+        # config derived with thread_id
+        assert graph.calls[0][1] == {"configurable": {"thread_id": "t1"}}
+
+    async def test_lock_contention_returns_rejected(self) -> None:
+        graph = FakeGraph(checkpointer=object())
+        reg = FakeReg(graph, "echo")
+        lock = InProcessThreadLock()
+        # Pre-acquire the same (name, thread_id) so the activity cannot get it.
+        assert lock.acquire("echo", "t1")
+        obs = RecordingObserver()
+        result = await execute_langgraph_run_impl(
+            _payload(thread_id="t1"), registry={"echo": reg}, thread_lock=lock, observer=obs
+        )
+        assert result.activity_status == "rejected"
+        assert obs.events == ["rejected"]
+
+    async def test_async_graph_with_config(self) -> None:
+        graph = FakeAsyncGraph(checkpointer=object(), result={"a": 3})
+        reg = FakeReg(graph, "echo", async_mode=True)
+        result = await execute_langgraph_run_impl(
+            _payload(thread_id="t1"), registry={"echo": reg}, thread_lock=InProcessThreadLock()
+        )
+        assert result.result == {"a": 3}
+        assert graph.calls[0][1] == {"configurable": {"thread_id": "t1"}}
+
+    async def test_explicit_config_passthrough(self) -> None:
+        graph = FakeGraph(checkpointer=object())
+        reg = FakeReg(graph, "echo")
+        cfg = {"configurable": {"thread_id": "t9", "extra": 1}}
+        await execute_langgraph_run_impl(
+            _payload(thread_id="t9", config=cfg),
+            registry={"echo": reg},
+            thread_lock=InProcessThreadLock(),
+        )
+        assert graph.calls[0][1] == cfg
+
+
+# --------------------------------------------------------------------------
+# Orchestrator
+# --------------------------------------------------------------------------
+class FakeContext:
+    def __init__(self, input_: Any) -> None:
+        self._input = input_
+        self.calls: list[tuple[str, Any]] = []
+
+    def get_input(self) -> Any:
+        return self._input
+
+    def call_activity(self, name: str, input_: Any) -> Any:
+        self.calls.append((name, input_))
+        return f"task:{name}"
+
+
+class TestOrchestrator:
+    def test_yields_single_activity_and_returns_result(self) -> None:
+        ctx = FakeContext({"run_id": "r1"})
+        gen = run_orchestration(ctx)
+        task = next(gen)
+        assert task == f"task:{ACTIVITY_NAME}"
+        assert ctx.calls == [(ACTIVITY_NAME, {"run_id": "r1"})]
+        # Feed the activity result back; generator returns it.
+        with pytest.raises(StopIteration) as exc:
+            gen.send({"activity_status": "success"})
+        assert exc.value.value == {"activity_status": "success"}
+
+
+# --------------------------------------------------------------------------
+# Lifecycle
+# --------------------------------------------------------------------------
+class TestRuntimeStatusStr:
+    def test_none_status(self) -> None:
+        assert runtime_status_str(None) is None
+
+    def test_no_runtime_status(self) -> None:
+        assert runtime_status_str(FakeStatus(None)) is None
+
+    def test_enum_member(self) -> None:
+        assert runtime_status_str(FakeStatus(_Enum("Running"))) == "Running"
+
+    def test_plain_string(self) -> None:
+        assert runtime_status_str(FakeStatus("Completed")) == "Completed"
+
+
+class TestCreateRun:
+    async def test_mints_run_id(self) -> None:
+        client = FakeDurableClient()
+        code, body = await create_run_impl(
+            client, ORCHESTRATOR_NAME, {"input": {"x": 1}}, graph_name="echo"
+        )
+        assert code == 202
+        assert body["status"] == "pending"
+        assert body["run_id"]
+        assert client.started[0][0] == ORCHESTRATOR_NAME
+
+    async def test_uses_provided_run_id(self) -> None:
+        client = FakeDurableClient()
+        code, body = await create_run_impl(
+            client, ORCHESTRATOR_NAME, {"run_id": "fixed", "input": 1}, graph_name="echo"
+        )
+        assert body["run_id"] == "fixed"
+        assert client.started[0][1] == "fixed"
+
+    async def test_derives_thread_id_from_config(self) -> None:
+        client = FakeDurableClient()
+        await create_run_impl(
+            client,
+            ORCHESTRATOR_NAME,
+            {"input": 1, "config": {"configurable": {"thread_id": "t5"}}},
+            graph_name="echo",
+        )
+        sent_payload = client.started[0][2]
+        assert sent_payload["thread_id"] == "t5"
+
+
+class TestGetRun:
+    async def test_not_found(self) -> None:
+        code, body = await get_run_impl(FakeDurableClient(status=None), "r1")
+        assert code == 404
+        assert body["error"] == "run not found"
+
+    async def test_completed_success(self) -> None:
+        output = {"activity_status": "success", "result": {"y": 1}}
+        client = FakeDurableClient(status=FakeStatus(_Enum("Completed"), output))
+        code, body = await get_run_impl(client, "r1")
+        assert code == 200
+        assert body["status"] == "success"
+        assert body["output"] == output
+
+    async def test_running(self) -> None:
+        client = FakeDurableClient(status=FakeStatus(_Enum("Running")))
+        code, body = await get_run_impl(client, "r1")
+        assert code == 200
+        assert body["status"] == "running"
+
+
+class TestCancelRun:
+    async def test_not_found(self) -> None:
+        code, body = await cancel_run_impl(FakeDurableClient(status=None), "r1")
+        assert code == 404
+
+    async def test_terminates(self) -> None:
+        client = FakeDurableClient(status=FakeStatus(_Enum("Running")))
+        code, body = await cancel_run_impl(client, "r1")
+        assert code == 202
+        assert body["status"] == "cancelled"
+        assert client.terminated == [("r1", "cancelled by client")]
+
+
+# --------------------------------------------------------------------------
+# State: normalize_status edge cases not covered elsewhere
+# --------------------------------------------------------------------------
+class TestNormalizeStatus:
+    @pytest.mark.parametrize(
+        "runtime,output,expected",
+        [
+            ("Pending", None, "pending"),
+            ("", None, "running"),
+            ("Running", None, "running"),
+            ("ContinuedAsNew", None, "running"),
+            ("Suspended", None, "running"),
+            ("Completed", {"activity_status": "success"}, "success"),
+            ("Completed", {"activity_status": "error"}, "error"),
+            ("Completed", {"activity_status": "rejected"}, "error"),
+            ("Completed", None, "success"),
+            ("Failed", None, "error"),
+            ("Terminated", None, "cancelled"),
+            ("Canceled", None, "cancelled"),
+            ("Cancelled", None, "cancelled"),
+            ("Weird", None, "running"),
+            (None, None, "running"),
+        ],
+    )
+    def test_mapping(self, runtime: Any, output: Any, expected: str) -> None:
+        assert normalize_status(runtime, output) == expected
+
+
+# --------------------------------------------------------------------------
+# Runtime HTTP adapters
+# --------------------------------------------------------------------------
+def _req(
+    *, route_params: dict[str, str], body: bytes = b"", method: str = "POST"
+) -> func.HttpRequest:
+    return func.HttpRequest(method=method, url="/api/x", body=body, route_params=route_params)
+
+
+class TestParseBody:
+    def test_empty_is_empty_object(self) -> None:
+        body, err = _parse_body(_req(route_params={}, body=b""), max_bytes=100)
+        assert body == {} and err is None
+
+    def test_too_large(self) -> None:
+        body, err = _parse_body(_req(route_params={}, body=b"x" * 50), max_bytes=10)
+        assert body is None and err is not None and "exceeds" in err
+
+    def test_invalid_json(self) -> None:
+        body, err = _parse_body(_req(route_params={}, body=b"{bad"), max_bytes=100)
+        assert body is None and "valid JSON" in (err or "")
+
+    def test_non_object(self) -> None:
+        body, err = _parse_body(_req(route_params={}, body=b"[1,2]"), max_bytes=100)
+        assert body is None and "JSON object" in (err or "")
+
+    def test_valid_object(self) -> None:
+        body, err = _parse_body(
+            _req(route_params={}, body=json.dumps({"a": 1}).encode()), max_bytes=100
+        )
+        assert body == {"a": 1} and err is None
+
+
+class TestCreateRunHttp:
+    async def test_unknown_graph_404(self) -> None:
+        reg = FakeReg(FakeGraph(), "echo")
+        resp = await create_run_http(
+            FakeDurableClient(),
+            _req(route_params={"name": "nope"}),
+            registry={"echo": reg},
+        )
+        assert resp.status_code == 404
+
+    async def test_bad_body_400(self) -> None:
+        reg = FakeReg(FakeGraph(), "echo")
+        resp = await create_run_http(
+            FakeDurableClient(),
+            _req(route_params={"name": "echo"}, body=b"[1]"),
+            registry={"echo": reg},
+        )
+        assert resp.status_code == 400
+
+    async def test_success_202(self) -> None:
+        reg = FakeReg(FakeGraph(), "echo")
+        client = FakeDurableClient()
+        resp = await create_run_http(
+            client,
+            _req(route_params={"name": "echo"}, body=json.dumps({"input": {"x": 1}}).encode()),
+            registry={"echo": reg},
+        )
+        assert resp.status_code == 202
+        payload = json.loads(resp.get_body())
+        assert payload["status"] == "pending"
+
+
+class TestGetCancelHttp:
+    async def test_get_run_http(self) -> None:
+        client = FakeDurableClient(status=FakeStatus(_Enum("Running")))
+        resp = await get_run_http(client, _req(route_params={"run_id": "r1"}, method="GET"))
+        assert resp.status_code == 200
+        assert json.loads(resp.get_body())["status"] == "running"
+
+    async def test_cancel_run_http(self) -> None:
+        client = FakeDurableClient(status=FakeStatus(_Enum("Running")))
+        resp = await cancel_run_http(client, _req(route_params={"run_id": "r1"}))
+        assert resp.status_code == 202
+
+
+# --------------------------------------------------------------------------
+# Runtime registration / app integration
+# --------------------------------------------------------------------------
+class TestRuntimeRegistration:
+    def test_create_durable_function_app_returns_dfapp(self) -> None:
+        app = create_durable_function_app(func.AuthLevel.FUNCTION)
+        assert type(app).__name__ == "DFApp"
+
+    def test_register_durable_runtime_registers_all(self) -> None:
+        app = create_durable_function_app(func.AuthLevel.FUNCTION)
+        register_durable_runtime(
+            app, DurableRuntimeDeps(registry={}, thread_lock=InProcessThreadLock())
+        )
+        names = {f.get_function_name() for f in app.get_functions()}
+        assert names == {
+            ORCHESTRATOR_NAME,
+            "execute_langgraph_run",
+            "aflg_durable_create_run",
+            "aflg_durable_get_run",
+            "aflg_durable_cancel_run",
+        }
+
+    async def test_registered_activity_executes_graph(self) -> None:
+        """The registered activity closure rehydrates payload and runs the graph."""
+        graph = FakeGraph(result={"z": 9})
+        reg = FakeReg(graph, "echo")
+        app = create_durable_function_app(func.AuthLevel.FUNCTION)
+        register_durable_runtime(
+            app, DurableRuntimeDeps(registry={"echo": reg}, thread_lock=InProcessThreadLock())
+        )
+        activity = next(
+            f for f in app.get_functions() if f.get_function_name() == "execute_langgraph_run"
+        )
+        fn = activity.get_user_function()
+        result = await fn(_payload(graph_name="echo").to_dict())
+        assert result["activity_status"] == "success"
+        assert result["result"] == {"z": 9}
+
+    def test_registered_orchestrator_is_registered(self) -> None:
+        app = create_durable_function_app(func.AuthLevel.FUNCTION)
+        register_durable_runtime(
+            app, DurableRuntimeDeps(registry={}, thread_lock=InProcessThreadLock())
+        )
+        orch = next(f for f in app.get_functions() if f.get_function_name() == ORCHESTRATOR_NAME)
+        assert orch.get_user_function() is not None
+
+
+class TestAppIntegration:
+    def test_durable_app_wires_lifecycle_routes(self) -> None:
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION, async_runs="durable")
+        app.register(graph=FakeGraph(), name="echo")
+        fa = app.function_app
+        assert type(fa).__name__ == "DFApp"
+        names = {f.get_function_name() for f in fa.get_functions()}
+        assert {"aflg_durable_create_run", ORCHESTRATOR_NAME, "execute_langgraph_run"} <= names
+
+    def test_default_app_is_plain_function_app(self) -> None:
+        app = LangGraphApp(auth_level=func.AuthLevel.FUNCTION)
+        app.register(graph=FakeGraph(), name="echo")
+        fa = app.function_app
+        assert type(fa).__name__ == "FunctionApp"
+        names = {f.get_function_name() for f in fa.get_functions()}
+        assert not any(n and n.startswith("aflg_durable_") for n in names)

--- a/tests/test_durable_state.py
+++ b/tests/test_durable_state.py
@@ -1,0 +1,136 @@
+"""Unit tests for the pure durable state models and status mapping.
+
+These tests import only :mod:`azure_functions_langgraph.durable._state`, which
+has no ``azure.durable_functions`` dependency, so they run without the
+``durable`` extra or any Azure host.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from azure_functions_langgraph.durable._state import (
+    DurableRunPayload,
+    DurableRunResult,
+    normalize_status,
+    serialize_error,
+)
+
+
+class TestSerializeError:
+    def test_type_and_message_only(self) -> None:
+        err = serialize_error(ValueError("boom"))
+        assert err == {"type": "ValueError", "message": "boom"}
+
+    def test_no_traceback_or_extra_keys(self) -> None:
+        try:
+            raise RuntimeError("bad")
+        except RuntimeError as exc:
+            err = serialize_error(exc)
+        assert set(err) == {"type", "message"}
+        assert err["type"] == "RuntimeError"
+
+
+class TestDurableRunPayload:
+    def test_round_trip(self) -> None:
+        payload = DurableRunPayload(
+            run_id="r1",
+            graph_name="agent",
+            input={"messages": []},
+            thread_id="t1",
+            config={"configurable": {"thread_id": "t1"}},
+            assistant_id="a1",
+            correlation_id="c1",
+        )
+        restored = DurableRunPayload.from_dict(payload.to_dict())
+        assert restored == payload
+
+    def test_from_dict_defaults(self) -> None:
+        payload = DurableRunPayload.from_dict(
+            {"run_id": "r1", "graph_name": "agent", "input": None}
+        )
+        assert payload.thread_id is None
+        assert payload.config == {}
+        assert payload.assistant_id is None
+        assert payload.correlation_id is None
+
+    def test_from_dict_coerces_ids_to_str(self) -> None:
+        payload = DurableRunPayload.from_dict({"run_id": 123, "graph_name": 456, "input": "x"})
+        assert payload.run_id == "123"
+        assert payload.graph_name == "456"
+
+    def test_from_dict_none_config_becomes_empty(self) -> None:
+        payload = DurableRunPayload.from_dict(
+            {"run_id": "r", "graph_name": "g", "input": 1, "config": None}
+        )
+        assert payload.config == {}
+
+
+class TestDurableRunResult:
+    def test_success_factory_and_round_trip(self) -> None:
+        result = DurableRunResult.success("r1", {"answer": 42})
+        assert result.activity_status == "success"
+        assert result.result == {"answer": 42}
+        assert result.error is None
+        assert DurableRunResult.from_dict(result.to_dict()) == result
+
+    def test_failure_factory(self) -> None:
+        result = DurableRunResult.failure("r1", ValueError("nope"))
+        assert result.activity_status == "error"
+        assert result.result is None
+        assert result.error == {"type": "ValueError", "message": "nope"}
+
+    def test_rejected_factory(self) -> None:
+        result = DurableRunResult.rejected("r1", "thread busy")
+        assert result.activity_status == "rejected"
+        assert result.error == {
+            "type": "ThreadContentionError",
+            "message": "thread busy",
+        }
+
+    def test_from_dict_round_trip_error(self) -> None:
+        result = DurableRunResult.failure("r1", RuntimeError("x"))
+        assert DurableRunResult.from_dict(result.to_dict()) == result
+
+
+class TestNormalizeStatus:
+    @pytest.mark.parametrize(
+        ("runtime_status", "expected"),
+        [
+            ("Pending", "pending"),
+            ("Running", "running"),
+            ("Suspended", "running"),
+            ("ContinuedAsNew", "running"),
+            ("Failed", "error"),
+            ("Terminated", "cancelled"),
+            ("Canceled", "cancelled"),
+            ("Cancelled", "cancelled"),
+        ],
+    )
+    def test_simple_statuses(self, runtime_status: str, expected: str) -> None:
+        assert normalize_status(runtime_status) == expected
+
+    def test_none_and_empty_are_running(self) -> None:
+        assert normalize_status(None) == "running"
+        assert normalize_status("") == "running"
+
+    def test_unknown_status_is_running(self) -> None:
+        assert normalize_status("SomethingNew") == "running"
+
+    def test_completed_without_output_is_success(self) -> None:
+        assert normalize_status("Completed") == "success"
+
+    def test_completed_with_success_output(self) -> None:
+        output = DurableRunResult.success("r1", {"x": 1}).to_dict()
+        assert normalize_status("Completed", output) == "success"
+
+    def test_completed_with_error_output_is_error(self) -> None:
+        output = DurableRunResult.failure("r1", ValueError("boom")).to_dict()
+        assert normalize_status("Completed", output) == "error"
+
+    def test_completed_with_rejected_output_is_error(self) -> None:
+        output = DurableRunResult.rejected("r1", "busy").to_dict()
+        assert normalize_status("Completed", output) == "error"
+
+    def test_whitespace_is_stripped(self) -> None:
+        assert normalize_status("  Completed  ") == "success"

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -27,6 +27,7 @@ GRAPH_EXAMPLES: tuple[tuple[str, str], ...] = (
     ("run_observer_otel", "compiled_graph"),
     ("service_bus_agent", "compiled_graph"),
     ("true_streaming_agent", "compiled_graph"),
+    ("durable_async_agent", "compiled_graph"),
 )
 
 
@@ -85,6 +86,7 @@ EXAMPLE_DIRS = (
     "run_observer_otel",
     "service_bus_agent",
     "true_streaming_agent",
+    "durable_async_agent",
 )
 
 


### PR DESCRIPTION
## Summary
- Adds an **opt-in, experimental** Durable Functions-backed async run lifecycle via `LangGraphApp(async_runs="durable")`, gated behind a new optional `durable` extra (`pip install azure-functions-langgraph[durable]`).
- New native control-plane routes on top of the classic invoke/stream surface:
  - `POST /api/graphs/{name}/runs` → `202` with `run_id` + `pending`
  - `GET /api/runs/{run_id}` → normalized status (`pending`/`running`/`completed`/`failed`/`canceled`)
  - `POST /api/runs/{run_id}/cancel` → terminate an in-flight run
- Graph user code executes **only inside a Durable activity, never the orchestrator**, preserving Durable replay determinism. Durable history is **not** a replacement for LangGraph checkpoints.

## Implementation
- New `durable/` package: `_state`, `_activity`, `_orchestrator`, `_lifecycle`, `_runtime` (lazy `azure.durable_functions` import so the base package imports without the extra).
- `app.py` wiring: `AsyncRunsMode` alias, `async_runs` field, `_new_function_app()` / `_register_durable_runtime()`; durable mode builds a `DFApp`, default stays a plain `FunctionApp`.
- Deployable `examples/durable_async_agent/` with a create → poll → result → cancel README walkthrough, registered in the examples smoke suite.

## Docs
- README "Durable async run lifecycle" section, COMPATIBILITY.md non-SDK surface table, and production-guide "Async runs via Durable Functions" subsection (replaces the stale "no built-in cancellation endpoint" note).

## Verification
- `hatch run lint` (ruff + mypy strict) clean across 90 source files.
- Full `hatch run pytest --cov` green; total coverage **96.59%** (≥95% gate). 77 new durable unit tests use deterministic fakes; example smoke test passes.

Closes #408.