### PR TITLE
fix(deps): drop unsupported semver cooldown keys for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,9 +38,6 @@ updates:
     # bypass cooldown and stay on the fast path. See issue #381.
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
       include:
         - "*"
     # actions/upload-artifact + actions/download-artifact are deliberately held


### PR DESCRIPTION
The `github-actions` ecosystem does not support `semver-major-days`/`semver-minor-days`/`semver-patch-days` under `cooldown` (only `default-days`). Dependabot's config validator currently fails on every PR in this repo. This removes the unsupported keys, keeping `default-days` for github-actions.